### PR TITLE
Ensure bundle dependencies are overwritable by env

### DIFF
--- a/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift-logging/loki-operator:latest
+    containerImage: quay.io/openshift-logging/loki-operator:v0.0.1
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -209,6 +209,9 @@ spec:
                   name: loki-operator-metrics-cert
               - command:
                 - /manager
+                env:
+                - name: LOKI_IMAGE
+                  value: docker.io/grafana/loki:2.2.1
                 image: quay.io/openshift-logging/loki-operator:v0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,6 +15,9 @@ spec:
       containers:
       - command:
         - /manager
+        env:
+        - name: LOKI_IMAGE
+          value: docker.io/grafana/loki:2.2.1
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift-logging/loki-operator:latest
+    containerImage: quay.io/openshift-logging/loki-operator:v0.0.1
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements

--- a/internal/handlers/lokistack_create.go
+++ b/internal/handlers/lokistack_create.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"os"
 
 	"github.com/ViaQ/logerr/kverrors"
 	"github.com/ViaQ/logerr/log"
@@ -29,10 +30,16 @@ func CreateLokiStack(ctx context.Context, req ctrl.Request, k k8s.Client) error 
 		return kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
 	}
 
+	img := os.Getenv("LOKI_IMAGE")
+	if img == "" {
+		img = manifests.DefaultContainerImage
+	}
+
 	// Here we will translate the lokiv1beta1.LokiStack options into manifest options
 	opts := manifests.Options{
 		Name:      req.Name,
 		Namespace: req.Namespace,
+		Image:     img,
 		Stack:     stack.Spec,
 	}
 

--- a/internal/manifests/build.go
+++ b/internal/manifests/build.go
@@ -20,7 +20,7 @@ func BuildAll(opt Options) ([]client.Object, error) {
 	}
 
 	res = append(res, cm)
-	res = append(res, BuildDistributor(opt.Name)...)
+	res = append(res, BuildDistributor(opt)...)
 
 	ingesterObjects, err := BuildIngester(opt)
 	if err != nil {
@@ -34,7 +34,7 @@ func BuildAll(opt Options) ([]client.Object, error) {
 	}
 	res = append(res, querierObjects...)
 
-	res = append(res, BuildQueryFrontend(opt.Name)...)
+	res = append(res, BuildQueryFrontend(opt)...)
 	res = append(res, LokiGossipRingService(opt.Name))
 
 	return res, nil

--- a/internal/manifests/ingester.go
+++ b/internal/manifests/ingester.go
@@ -41,7 +41,7 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 		},
 		Containers: []corev1.Container{
 			{
-				Image: containerImage,
+				Image: opts.Image,
 				Name:  "loki-ingester",
 				Args: []string{
 					"-target=ingester",

--- a/internal/manifests/options.go
+++ b/internal/manifests/options.go
@@ -10,6 +10,7 @@ import (
 type Options struct {
 	Name      string
 	Namespace string
+	Image     string
 
 	Stack lokiv1beta1.LokiStackSpec
 }

--- a/internal/manifests/querier.go
+++ b/internal/manifests/querier.go
@@ -41,7 +41,7 @@ func NewQuerierStatefulSet(opts Options) *appsv1.StatefulSet {
 		},
 		Containers: []corev1.Container{
 			{
-				Image: containerImage,
+				Image: opts.Image,
 				Name:  "loki-querier",
 				Args: []string{
 					"-target=querier",

--- a/internal/manifests/query-frontend.go
+++ b/internal/manifests/query-frontend.go
@@ -15,16 +15,16 @@ import (
 )
 
 // BuildQueryFrontend returns a list of k8s objects for Loki QueryFrontend
-func BuildQueryFrontend(stackName string) []client.Object {
+func BuildQueryFrontend(opts Options) []client.Object {
 	return []client.Object{
-		NewQueryFrontendDeployment(stackName),
-		NewQueryFrontendGRPCService(stackName),
-		NewQueryFrontendHTTPService(stackName),
+		NewQueryFrontendDeployment(opts),
+		NewQueryFrontendGRPCService(opts.Name),
+		NewQueryFrontendHTTPService(opts.Name),
 	}
 }
 
 // NewQueryFrontendDeployment creates a deployment object for a query-frontend
-func NewQueryFrontendDeployment(stackName string) *appsv1.Deployment {
+func NewQueryFrontendDeployment(opts Options) *appsv1.Deployment {
 	podSpec := corev1.PodSpec{
 		Volumes: []corev1.Volume{
 			{
@@ -32,7 +32,7 @@ func NewQueryFrontendDeployment(stackName string) *appsv1.Deployment {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: lokiConfigMapName(stackName),
+							Name: lokiConfigMapName(opts.Name),
 						},
 					},
 				},
@@ -46,7 +46,7 @@ func NewQueryFrontendDeployment(stackName string) *appsv1.Deployment {
 		},
 		Containers: []corev1.Container{
 			{
-				Image: containerImage,
+				Image: opts.Image,
 				Name:  "loki-query-frontend",
 				Args: []string{
 					"-target=query-frontend",
@@ -111,7 +111,7 @@ func NewQueryFrontendDeployment(stackName string) *appsv1.Deployment {
 		},
 	}
 
-	l := ComponentLabels("query-frontend", stackName)
+	l := ComponentLabels("query-frontend", opts.Name)
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -119,7 +119,7 @@ func NewQueryFrontendDeployment(stackName string) *appsv1.Deployment {
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   fmt.Sprintf("loki-query-frontend-%s", stackName),
+			Name:   fmt.Sprintf("loki-query-frontend-%s", opts.Name),
 			Labels: l,
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -129,7 +129,7 @@ func NewQueryFrontendDeployment(stackName string) *appsv1.Deployment {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   fmt.Sprintf("loki-query-frontend-%s", stackName),
+					Name:   fmt.Sprintf("loki-query-frontend-%s", opts.Name),
 					Labels: labels.Merge(l, GossipLabels()),
 				},
 				Spec: podSpec,

--- a/internal/manifests/var.go
+++ b/internal/manifests/var.go
@@ -7,10 +7,12 @@ import (
 )
 
 const (
-	containerImage = "docker.io/grafana/loki:2.1.0"
-	gossipPort     = 7946
-	httpPort       = 3100
-	grpcPort       = 9095
+	// DefaultContainerImage declares the default fallback for loki image.
+	DefaultContainerImage = "docker.io/grafana/loki:2.2.1"
+
+	gossipPort = 7946
+	httpPort   = 3100
+	grpcPort   = 9095
 )
 
 func commonLabels(stackName string) map[string]string {

--- a/manifests/5.1.preview.1/loki-operator.v5.1.preview.1.clusterserviceversion.yaml
+++ b/manifests/5.1.preview.1/loki-operator.v5.1.preview.1.clusterserviceversion.yaml
@@ -18,7 +18,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: OpenShift Optional, Logging & Tracing
     certified: "false"
-    containerImage: quay.io/openshift-logging/loki-operator:latest
+    containerImage: quay.io/openshift-logging/loki-operator:v0.0.1
     description: |
       The Loki Operator for OCP provides a means for configuring and managing a Loki stack for cluster logging.
       ## Prerequisites and Requirements
@@ -209,6 +209,9 @@ spec:
                   name: loki-operator-metrics-cert
               - command:
                 - /manager
+                env:
+                - name: LOKI_IMAGE
+                  value: docker.io/grafana/loki:2.2.1
                 image: quay.io/openshift-logging/loki-operator:v0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:


### PR DESCRIPTION
This change set ensures that operator bundle dependencies are overridable via enviroment variables (e.g. `LOKI_IMAGE`). This enables to pin the images to internal builds.

Ref: https://issues.redhat.com/browse/LOG-1228