### PR TITLE
Use RELATED_IMAGE_LOKI for operand img pinning on production builds

### DIFF
--- a/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -315,27 +315,11 @@ spec:
                 name: loki-operator-controller-manager
             spec:
               containers:
-              - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --tls-cert-file=/var/run/secrets/serving-cert/tls.crt
-                - --tls-private-key-file=/var/run/secrets/serving-cert/tls.key
-                - --v=2
-                image: quay.io/openshift/origin-kube-rbac-proxy:latest
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                resources: {}
-                volumeMounts:
-                - mountPath: /var/run/secrets/serving-cert
-                  name: loki-operator-metrics-cert
               - command:
                 - /manager
                 env:
-                - name: LOKI_IMAGE
-                  value: docker.io/grafana/loki:2.2.1
+                - name: RELATED_IMAGE_LOKI
+                  value: quay.io/openshift-logging/loki:v2.2.0-10
                 image: quay.io/openshift-logging/loki-operator:v0.0.1
                 imagePullPolicy: IfNotPresent
                 livenessProbe:
@@ -357,6 +341,22 @@ spec:
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --tls-cert-file=/var/run/secrets/serving-cert/tls.crt
+                - --tls-private-key-file=/var/run/secrets/serving-cert/tls.key
+                - --v=2
+                image: quay.io/openshift/origin-kube-rbac-proxy:latest
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources: {}
+                volumeMounts:
+                - mountPath: /var/run/secrets/serving-cert
+                  name: loki-operator-metrics-cert
               terminationGracePeriodSeconds: 10
               volumes:
               - name: loki-operator-metrics-cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -15,9 +15,6 @@ spec:
       containers:
       - command:
         - /manager
-        env:
-        - name: LOKI_IMAGE
-          value: docker.io/grafana/loki:2.2.1
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/config/overlays/production/kustomization.yaml
+++ b/config/overlays/production/kustomization.yaml
@@ -35,6 +35,7 @@ patchesStrategicMerge:
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
+- manager_related_image_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type

--- a/config/overlays/production/manager_related_image_patch.yaml
+++ b/config/overlays/production/manager_related_image_patch.yaml
@@ -1,0 +1,14 @@
+# This patch inject a sidecar container which is a HTTP proxy for the
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          env:
+          - name: RELATED_IMAGE_LOKI
+            value: quay.io/openshift-logging/loki:v2.2.0-10

--- a/internal/handlers/lokistack_create.go
+++ b/internal/handlers/lokistack_create.go
@@ -30,7 +30,7 @@ func CreateLokiStack(ctx context.Context, req ctrl.Request, k k8s.Client) error 
 		return kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
 	}
 
-	img := os.Getenv("LOKI_IMAGE")
+	img := os.Getenv("RELATED_IMAGE_LOKI")
 	if img == "" {
 		img = manifests.DefaultContainerImage
 	}


### PR DESCRIPTION
This PR provides a fix for pinning the operand image for production builds, i.e.:
- Rename `LOKI_IMAGE` to `RELATED_IMAGE_LOKI` according to [OSBS docs](https://osbs.readthedocs.io/en/latest/users.html#creating-the-relatedimages-section)
- Populate the `RELATED_IMAGE_LOKI` env var in the CSV only for production builds. Development builds use the fallback provided in the code base.