### PR TITLE
add some tests to verify services will match pods

### DIFF
--- a/internal/manifests/service_test.go
+++ b/internal/manifests/service_test.go
@@ -1,0 +1,152 @@
+package manifests
+
+import (
+	"fmt"
+	"testing"
+
+	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Test that the service ports have matching deployment/statefulset/daemonset ports on the podspec.
+func TestServicesMatchPorts(t *testing.T) {
+	type test struct {
+		Services   []*corev1.Service
+		Containers []corev1.Container
+	}
+	opt := Options{
+		Name:      "test",
+		Namespace: "test",
+		Image:     "test",
+		Stack: lokiv1beta1.LokiStackSpec{
+			Size: lokiv1beta1.OneXExtraSmallSize,
+		},
+	}
+
+	table := []test{
+		{
+			Containers: NewDistributorDeployment(opt).Spec.Template.Spec.Containers,
+			Services: []*corev1.Service{
+				NewDistributorGRPCService(opt.Name),
+				NewDistributorHTTPService(opt.Name),
+			},
+		},
+		{
+			Containers: NewIngesterStatefulSet(opt).Spec.Template.Spec.Containers,
+			Services: []*corev1.Service{
+				NewIngesterGRPCService(opt),
+				NewIngesterHTTPService(opt),
+			},
+		},
+		{
+			Containers: NewQuerierStatefulSet(opt).Spec.Template.Spec.Containers,
+			Services: []*corev1.Service{
+				NewQuerierGRPCService(opt.Name),
+				NewQuerierHTTPService(opt.Name),
+			},
+		},
+		{
+			Containers: NewQueryFrontendDeployment(opt).Spec.Template.Spec.Containers,
+			Services: []*corev1.Service{
+				NewQueryFrontendGRPCService(opt.Name),
+				NewQueryFrontendHTTPService(opt.Name),
+			},
+		},
+	}
+
+	containerHasPort := func(containers []corev1.Container, port int32) bool {
+		for _, container := range containers {
+			for _, p := range container.Ports {
+				if p.ContainerPort == port {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	for _, tst := range table {
+		for _, service := range tst.Services {
+			for _, port := range service.Spec.Ports {
+				// rescope for t.Parallel
+				tst, service, port := tst, service, port
+				testName := fmt.Sprintf("%s_%d", service.GetName(), port.Port)
+				t.Run(testName, func(t *testing.T) {
+					t.Parallel()
+					found := containerHasPort(tst.Containers, port.Port)
+					assert.True(t, found, "Service port (%d) does not match any port in the defined containers", port.Port)
+				})
+			}
+		}
+	}
+
+}
+
+// Test that all services match the labels of their deployments/statefulsets so that we know all services will
+// work when deployed.
+func TestServicesMatchLabels(t *testing.T) {
+	type test struct {
+		Services []*corev1.Service
+		Object   client.Object
+	}
+
+	opt := Options{
+		Name:      "test",
+		Namespace: "test",
+		Image:     "test",
+		Stack: lokiv1beta1.LokiStackSpec{
+			Size: lokiv1beta1.OneXExtraSmallSize,
+		},
+	}
+
+	table := []test{
+		{
+			Object: NewDistributorDeployment(opt),
+			Services: []*corev1.Service{
+				NewDistributorGRPCService(opt.Name),
+				NewDistributorHTTPService(opt.Name),
+			},
+		},
+		{
+			Object: NewIngesterStatefulSet(opt),
+			Services: []*corev1.Service{
+				NewIngesterGRPCService(opt),
+				NewIngesterHTTPService(opt),
+			},
+		},
+		{
+			Object: NewQuerierStatefulSet(opt),
+			Services: []*corev1.Service{
+				NewQuerierGRPCService(opt.Name),
+				NewQuerierHTTPService(opt.Name),
+			},
+		},
+		{
+			Object: NewQueryFrontendDeployment(opt),
+			Services: []*corev1.Service{
+				NewQueryFrontendGRPCService(opt.Name),
+				NewQueryFrontendHTTPService(opt.Name),
+			},
+		},
+	}
+
+	for _, tst := range table {
+		for _, service := range tst.Services {
+			// rescope for t.Parallel()
+			tst, service := tst, service
+
+			testName := fmt.Sprintf("%s_%s", tst.Object.GetName(), service.GetName())
+			t.Run(testName, func(t *testing.T) {
+				t.Parallel()
+				for k, v := range service.Spec.Selector {
+					if assert.Contains(t, tst.Object.GetLabels(), k) {
+						// only assert Equal if the previous assertion is successful or this will panic
+						assert.Equal(t, v, tst.Object.GetLabels()[k])
+					}
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
We need to guarantee that all service ports match pod ports
We need to guarantee that all service labels match pod labels


```=== RUN   TestServicesMatchPorts
=== RUN   TestServicesMatchPorts/loki-distributor-http-test_3100
=== RUN   TestServicesMatchPorts/loki-distributor-grpc-test_9095
=== RUN   TestServicesMatchPorts/loki-ingester-grpc-test_9095
=== RUN   TestServicesMatchPorts/loki-ingester-http-test_3100
=== RUN   TestServicesMatchPorts/loki-querier-grpc-test_9095
=== RUN   TestServicesMatchPorts/loki-querier-http-test_3100
=== RUN   TestServicesMatchPorts/loki-query-frontend-grpc-test_9095
=== RUN   TestServicesMatchPorts/loki-query-frontend-http-test_3100
--- PASS: TestServicesMatchPorts (0.00s)
    --- PASS: TestServicesMatchPorts/loki-distributor-http-test_3100 (0.00s)
    --- PASS: TestServicesMatchPorts/loki-distributor-grpc-test_9095 (0.00s)
    --- PASS: TestServicesMatchPorts/loki-ingester-grpc-test_9095 (0.00s)
    --- PASS: TestServicesMatchPorts/loki-ingester-http-test_3100 (0.00s)
    --- PASS: TestServicesMatchPorts/loki-querier-grpc-test_9095 (0.00s)
    --- PASS: TestServicesMatchPorts/loki-querier-http-test_3100 (0.00s)
    --- PASS: TestServicesMatchPorts/loki-query-frontend-grpc-test_9095 (0.00s)
    --- PASS: TestServicesMatchPorts/loki-query-frontend-http-test_3100 (0.00s)
=== RUN   TestServicesMatchLabels
=== RUN   TestServicesMatchLabels/loki-distributor-test_loki-distributor-http-test
=== RUN   TestServicesMatchLabels/loki-distributor-test_loki-distributor-grpc-test
=== RUN   TestServicesMatchLabels/loki-ingester-test_loki-ingester-grpc-test
=== RUN   TestServicesMatchLabels/loki-ingester-test_loki-ingester-http-test
=== RUN   TestServicesMatchLabels/loki-querier-test_loki-querier-grpc-test
=== RUN   TestServicesMatchLabels/loki-querier-test_loki-querier-http-test
=== RUN   TestServicesMatchLabels/loki-query-frontend-test_loki-query-frontend-grpc-test
=== RUN   TestServicesMatchLabels/loki-query-frontend-test_loki-query-frontend-http-test
--- PASS: TestServicesMatchLabels (0.00s)
    --- PASS: TestServicesMatchLabels/loki-distributor-test_loki-distributor-http-test (0.00s)
    --- PASS: TestServicesMatchLabels/loki-distributor-test_loki-distributor-grpc-test (0.00s)
    --- PASS: TestServicesMatchLabels/loki-ingester-test_loki-ingester-grpc-test (0.00s)
    --- PASS: TestServicesMatchLabels/loki-ingester-test_loki-ingester-http-test (0.00s)
    --- PASS: TestServicesMatchLabels/loki-querier-test_loki-querier-grpc-test (0.00s)
    --- PASS: TestServicesMatchLabels/loki-querier-test_loki-querier-http-test (0.00s)
    --- PASS: TestServicesMatchLabels/loki-query-frontend-test_loki-query-frontend-grpc-test (0.00s)
    --- PASS: TestServicesMatchLabels/loki-query-frontend-test_loki-query-frontend-http-test (0.00s)
=== RUN   TestConfigOptions_UserOptionsTakePrecedence
--- PASS: TestConfigOptions_UserOptionsTakePrecedence (0.00s)
=== RUN   TestNewIngesterStatefulSet_SelectorMatchesLabels
--- PASS: TestNewIngesterStatefulSet_SelectorMatchesLabels (0.00s)
=== RUN   TestNewQuerierStatefulSet_SelectorMatchesLabels
--- PASS: TestNewQuerierStatefulSet_SelectorMatchesLabels (0.00s)
PASS
ok  	github.com/ViaQ/loki-operator/internal/manifests	(cached)
?   	github.com/ViaQ/loki-operator/internal/manifests/internal/config	[no test files]
```