### PR TITLE
Add support for compactor

### DIFF
--- a/internal/manifests/build.go
+++ b/internal/manifests/build.go
@@ -28,6 +28,7 @@ func BuildAll(opt Options) ([]client.Object, error) {
 	}
 	res = append(res, querierObjects...)
 
+	res = append(res, BuildCompactor(opt)...)
 	res = append(res, BuildQueryFrontend(opt)...)
 	res = append(res, LokiGossipRingService(opt.Name))
 

--- a/internal/manifests/compactor.go
+++ b/internal/manifests/compactor.go
@@ -1,0 +1,196 @@
+package manifests
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BuildCompactor builds the k8s objects required to run Loki Compactor.
+func BuildCompactor(opts Options) []client.Object {
+	return []client.Object{
+		NewCompactorStatefulSet(opts),
+		NewCompactorGRPCService(opts),
+		NewCompactorHTTPService(opts),
+	}
+}
+
+// NewCompactorStatefulSet creates a statefulset object for a compactor.
+func NewCompactorStatefulSet(opt Options) *appsv1.StatefulSet {
+	podSpec := corev1.PodSpec{
+		Volumes: []corev1.Volume{
+			{
+				Name: configVolumeName,
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: lokiConfigMapName(opt.Name),
+						},
+					},
+				},
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Image: opt.Image,
+				Name:  "loki-compactor",
+				Args: []string{
+					"-target=compactor",
+					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
+				},
+				ReadinessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/ready",
+							Port:   intstr.FromInt(httpPort),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					InitialDelaySeconds: 15,
+					TimeoutSeconds:      1,
+				},
+				LivenessProbe: &corev1.Probe{
+					Handler: corev1.Handler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/metrics",
+							Port:   intstr.FromInt(httpPort),
+							Scheme: corev1.URISchemeHTTP,
+						},
+					},
+					TimeoutSeconds:   2,
+					PeriodSeconds:    30,
+					FailureThreshold: 10,
+				},
+				Ports: []corev1.ContainerPort{
+					{
+						Name:          "metrics",
+						ContainerPort: httpPort,
+					},
+					{
+						Name:          "grpc",
+						ContainerPort: grpcPort,
+					},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      configVolumeName,
+						ReadOnly:  false,
+						MountPath: config.LokiConfigMountDir,
+					},
+					{
+						Name:      storageVolumeName,
+						ReadOnly:  false,
+						MountPath: dataDirectory,
+					},
+				},
+			},
+		},
+	}
+
+	compactorLabels := ComponentLabels("compactor", opt.Name)
+
+	return &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "StatefulSet",
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   fmt.Sprintf("loki-compactor-%s", opt.Name),
+			Labels: compactorLabels,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			PodManagementPolicy:  appsv1.OrderedReadyPodManagement,
+			RevisionHistoryLimit: pointer.Int32Ptr(10),
+			Replicas:             pointer.Int32Ptr(opt.Stack.Template.Compactor.Replicas),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels.Merge(compactorLabels, GossipLabels()),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   fmt.Sprintf("loki-compactor-%s", opt.Name),
+					Labels: labels.Merge(compactorLabels, GossipLabels()),
+				},
+				Spec: podSpec,
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: compactorLabels,
+						Name:   storageVolumeName,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							// TODO: should we verify that this is possible with the given storage class first?
+							corev1.ReadWriteOnce,
+						},
+						Resources: corev1.ResourceRequirements{
+							Requests: map[corev1.ResourceName]resource.Quantity{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+						StorageClassName: pointer.StringPtr(opt.Stack.StorageClassName),
+					},
+				},
+			},
+		},
+	}
+}
+
+// NewCompactorGRPCService creates a k8s service for the compactor GRPC endpoint
+func NewCompactorGRPCService(opt Options) *corev1.Service {
+	l := ComponentLabels("compactor", opt.Name)
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   serviceNameCompactorGRPC(opt.Name),
+			Labels: l,
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Ports: []corev1.ServicePort{
+				{
+					Name: "grpc",
+					Port: grpcPort,
+				},
+			},
+			Selector: l,
+		},
+	}
+}
+
+// NewCompactorHTTPService creates a k8s service for the ingester HTTP endpoint
+func NewCompactorHTTPService(opt Options) *corev1.Service {
+	l := ComponentLabels("compactor", opt.Name)
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   serviceNameCompactorHTTP(opt.Name),
+			Labels: l,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name: "metrics",
+					Port: httpPort,
+				},
+			},
+			Selector: l,
+		},
+	}
+}

--- a/internal/manifests/config_test.go
+++ b/internal/manifests/config_test.go
@@ -53,6 +53,18 @@ func TestConfigOptions_AppliesStackSize(t *testing.T) {
 	}
 }
 
+func TestConfigOptions_CompactorHasOnlyOneReplica(t *testing.T) {
+	// regardless of what is provided by the default sizing parameters we should always prefer
+	// the user-defined values. This creates an all-inclusive manifests.Options and then checks
+	// that every value is present in the result
+	opts := randomConfigOptions()
+
+	res, err := manifests.ConfigOptions(opts)
+	require.NoError(t, err)
+
+	require.Equal(t, int32(1), res.Stack.Template.Compactor.Replicas)
+}
+
 func randomConfigOptions() manifests.Options {
 	return manifests.Options{
 		Name:      uuid.New().String(),
@@ -103,7 +115,7 @@ func randomConfigOptions() manifests.Options {
 			},
 			Template: lokiv1beta1.LokiTemplateSpec{
 				Compactor: lokiv1beta1.LokiComponentSpec{
-					Replicas: rand.Int31(),
+					Replicas: 1,
 					NodeSelector: map[string]string{
 						uuid.New().String(): uuid.New().String(),
 					},

--- a/internal/manifests/internal/config/loki-config.yaml
+++ b/internal/manifests/internal/config/loki-config.yaml
@@ -3,6 +3,10 @@ auth_enabled: false
 chunk_store_config:
   chunk_cache_config:
     enable_fifocache: yes
+compactor:
+  compaction_interval: 2h
+  shared_store: s3
+  working_directory: {{ .StorageDirectory }}/compactor
 distributor:
   ring:
     kvstore:

--- a/internal/manifests/service_test.go
+++ b/internal/manifests/service_test.go
@@ -54,6 +54,13 @@ func TestServicesMatchPorts(t *testing.T) {
 				NewQueryFrontendHTTPService(opt.Name),
 			},
 		},
+		{
+			Containers: NewCompactorStatefulSet(opt).Spec.Template.Spec.Containers,
+			Services: []*corev1.Service{
+				NewCompactorGRPCService(opt),
+				NewCompactorHTTPService(opt),
+			},
+		},
 	}
 
 	containerHasPort := func(containers []corev1.Container, port int32) bool {

--- a/internal/manifests/var.go
+++ b/internal/manifests/var.go
@@ -61,6 +61,14 @@ func serviceNameDistributorHTTP(stackName string) string {
 	return fmt.Sprintf("loki-distributor-http-%s", stackName)
 }
 
+func serviceNameCompactorGRPC(stackName string) string {
+	return fmt.Sprintf("loki-compactor-grpc-%s", stackName)
+}
+
+func serviceNameCompactorHTTP(stackName string) string {
+	return fmt.Sprintf("loki-compactor-http-%s", stackName)
+}
+
 func fqdn(serviceName, namespace string) string {
 	return fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace)
 }


### PR DESCRIPTION
This PR provides support for the Loki compactor component. It adds a new statefulset and two service (one for grpc, one for http metrics) to the manifests builds. In addition it ensures that only a single-replica compactor regardless user configuration.