### PR TITLE
Fix default CSV sample

### DIFF
--- a/api/v1beta1/lokistack_types.go
+++ b/api/v1beta1/lokistack_types.go
@@ -131,11 +131,11 @@ type ObjectStorageSpec struct {
 // QueryLimitSpec defines the limits applies at the query path.
 type QueryLimitSpec struct {
 
-	// MaxEntriesPerQuery defines the aximum number of log entries
+	// MaxEntriesLimitsPerQuery defines the maximum number of log entries
 	// that will be returned for a query.
 	//
 	// +optional
-	MaxEntriesPerQuery int32 `json:"maxEntriesPerQuery,omitempty"`
+	MaxEntriesLimitPerQuery int32 `json:"maxEntriesLimitPerQuery,omitempty"`
 
 	// MaxChunksPerQuery defines the maximum number of chunks
 	// that can be fetched by a single query.
@@ -177,11 +177,11 @@ type IngestionLimitSpec struct {
 	// +optional
 	MaxLabelValueLength int32 `json:"maxLabelValueLength,omitempty"`
 
-	// MaxLabelsPerSeries defines the maximum number of labels per series
+	// MaxLabelNamesPerSeries defines the maximum number of label names per series
 	// in each log stream.
 	//
 	// +optional
-	MaxLabelsPerSeries int32 `json:"maxLabelsPerSeries,omitempty"`
+	MaxLabelNamesPerSeries int32 `json:"maxLabelNamesPerSeries,omitempty"`
 
 	// MaxStreamsPerUser defines the maximum number of active streams
 	// per user, per ingester.

--- a/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -18,30 +18,30 @@ metadata:
                   "ingestionRate": 60,
                   "maxGlobalStreamsPerUser": 83,
                   "maxLabelLength": 40,
+                  "maxLabelNamesPerSeries": 45,
                   "maxLabelValueLength": 79,
-                  "maxLabelsPerSeries": 45,
                   "maxLineSize": 74,
                   "maxStreamsPerUser": 35
                 },
                 "queries": {
                   "maxChunksPerQuery": 90,
-                  "maxEntriesPerQuery": 8,
+                  "maxEntriesLimitPerQuery": 8,
                   "maxQuerySeries": 71
                 }
               }
             },
-            "replicationFactor": 60,
-            "size": "test",
+            "replicationFactor": 2,
+            "size": "OneXSmall",
             "storage": {
               "secret": {
                 "name": "test"
               },
               "url": "test"
             },
-            "storageClassName": "test",
+            "storageClassName": "standard",
             "template": {
               "compactor": {
-                "replicas": 23,
+                "replicas": 1,
                 "tolerations": [
                   {
                     "effect": "test",
@@ -79,7 +79,7 @@ metadata:
                 ]
               },
               "ingester": {
-                "replicas": 17,
+                "replicas": 3,
                 "tolerations": [
                   {
                     "effect": "test",
@@ -98,7 +98,7 @@ metadata:
                 ]
               },
               "querier": {
-                "replicas": 30,
+                "replicas": 3,
                 "tolerations": [
                   {
                     "effect": "test",
@@ -117,7 +117,7 @@ metadata:
                 ]
               },
               "queryFrontend": {
-                "replicas": 47,
+                "replicas": 3,
                 "tolerations": [
                   {
                     "effect": "test",

--- a/bundle/manifests/loki.openshift.io_lokistacks.yaml
+++ b/bundle/manifests/loki.openshift.io_lokistacks.yaml
@@ -63,12 +63,12 @@ spec:
                             description: MaxLabelLength defines the maximum number of characters allowed for label keys in log streams.
                             format: int32
                             type: integer
-                          maxLabelValueLength:
-                            description: MaxLabelValueLength defines the maximum number of characters allowed for label values in log streams.
+                          maxLabelNamesPerSeries:
+                            description: MaxLabelNamesPerSeries defines the maximum number of label names per series in each log stream.
                             format: int32
                             type: integer
-                          maxLabelsPerSeries:
-                            description: MaxLabelsPerSeries defines the maximum number of labels per series in each log stream.
+                          maxLabelValueLength:
+                            description: MaxLabelValueLength defines the maximum number of characters allowed for label values in log streams.
                             format: int32
                             type: integer
                           maxLineSize:
@@ -87,8 +87,8 @@ spec:
                             description: MaxChunksPerQuery defines the maximum number of chunks that can be fetched by a single query.
                             format: int32
                             type: integer
-                          maxEntriesPerQuery:
-                            description: MaxEntriesPerQuery defines the aximum number of log entries that will be returned for a query.
+                          maxEntriesLimitPerQuery:
+                            description: MaxEntriesLimitsPerQuery defines the maximum number of log entries that will be returned for a query.
                             format: int32
                             type: integer
                           maxQuerySeries:
@@ -120,12 +120,12 @@ spec:
                               description: MaxLabelLength defines the maximum number of characters allowed for label keys in log streams.
                               format: int32
                               type: integer
-                            maxLabelValueLength:
-                              description: MaxLabelValueLength defines the maximum number of characters allowed for label values in log streams.
+                            maxLabelNamesPerSeries:
+                              description: MaxLabelNamesPerSeries defines the maximum number of label names per series in each log stream.
                               format: int32
                               type: integer
-                            maxLabelsPerSeries:
-                              description: MaxLabelsPerSeries defines the maximum number of labels per series in each log stream.
+                            maxLabelValueLength:
+                              description: MaxLabelValueLength defines the maximum number of characters allowed for label values in log streams.
                               format: int32
                               type: integer
                             maxLineSize:
@@ -144,8 +144,8 @@ spec:
                               description: MaxChunksPerQuery defines the maximum number of chunks that can be fetched by a single query.
                               format: int32
                               type: integer
-                            maxEntriesPerQuery:
-                              description: MaxEntriesPerQuery defines the aximum number of log entries that will be returned for a query.
+                            maxEntriesLimitPerQuery:
+                              description: MaxEntriesLimitsPerQuery defines the maximum number of log entries that will be returned for a query.
                               format: int32
                               type: integer
                             maxQuerySeries:

--- a/config/crd/bases/loki.openshift.io_lokistacks.yaml
+++ b/config/crd/bases/loki.openshift.io_lokistacks.yaml
@@ -72,14 +72,14 @@ spec:
                               of characters allowed for label keys in log streams.
                             format: int32
                             type: integer
+                          maxLabelNamesPerSeries:
+                            description: MaxLabelNamesPerSeries defines the maximum
+                              number of label names per series in each log stream.
+                            format: int32
+                            type: integer
                           maxLabelValueLength:
                             description: MaxLabelValueLength defines the maximum number
                               of characters allowed for label values in log streams.
-                            format: int32
-                            type: integer
-                          maxLabelsPerSeries:
-                            description: MaxLabelsPerSeries defines the maximum number
-                              of labels per series in each log stream.
                             format: int32
                             type: integer
                           maxLineSize:
@@ -102,9 +102,9 @@ spec:
                               of chunks that can be fetched by a single query.
                             format: int32
                             type: integer
-                          maxEntriesPerQuery:
-                            description: MaxEntriesPerQuery defines the aximum number
-                              of log entries that will be returned for a query.
+                          maxEntriesLimitPerQuery:
+                            description: MaxEntriesLimitsPerQuery defines the maximum
+                              number of log entries that will be returned for a query.
                             format: int32
                             type: integer
                           maxQuerySeries:
@@ -145,15 +145,15 @@ spec:
                                 of characters allowed for label keys in log streams.
                               format: int32
                               type: integer
+                            maxLabelNamesPerSeries:
+                              description: MaxLabelNamesPerSeries defines the maximum
+                                number of label names per series in each log stream.
+                              format: int32
+                              type: integer
                             maxLabelValueLength:
                               description: MaxLabelValueLength defines the maximum
                                 number of characters allowed for label values in log
                                 streams.
-                              format: int32
-                              type: integer
-                            maxLabelsPerSeries:
-                              description: MaxLabelsPerSeries defines the maximum
-                                number of labels per series in each log stream.
                               format: int32
                               type: integer
                             maxLineSize:
@@ -176,9 +176,10 @@ spec:
                                 of chunks that can be fetched by a single query.
                               format: int32
                               type: integer
-                            maxEntriesPerQuery:
-                              description: MaxEntriesPerQuery defines the aximum number
-                                of log entries that will be returned for a query.
+                            maxEntriesLimitPerQuery:
+                              description: MaxEntriesLimitsPerQuery defines the maximum
+                                number of log entries that will be returned for a
+                                query.
                               format: int32
                               type: integer
                             maxQuerySeries:

--- a/config/overlays/development/kustomization.yaml
+++ b/config/overlays/development/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../manager
 
 # Adds namespace to all resources.
-namespace: openshift-logging
+namespace: default
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named

--- a/config/samples/loki_v1beta1_lokistack.yaml
+++ b/config/samples/loki_v1beta1_lokistack.yaml
@@ -11,23 +11,23 @@ spec:
         maxGlobalStreamsPerUser: 83
         maxLabelLength: 40
         maxLabelValueLength: 79
-        maxLabelsPerSeries: 45
+        maxLabelNamesPerSeries: 45
         maxLineSize: 74
         maxStreamsPerUser: 35
       queries:
         maxChunksPerQuery: 90
-        maxEntriesPerQuery: 8
+        maxEntriesLimitPerQuery: 8
         maxQuerySeries: 71
-  replicationFactor: 60
-  size: test
+  replicationFactor: 2
+  size: OneXSmall
   storage:
     secret:
       name: test
     url: test
-  storageClassName: test
+  storageClassName: standard
   template:
     compactor:
-      replicas: 23
+      replicas: 1
       tolerations:
         - effect: test
           key: test
@@ -53,7 +53,7 @@ spec:
           tolerationSeconds: 9
           value: test
     ingester:
-      replicas: 17
+      replicas: 3
       tolerations:
         - effect: test
           key: test
@@ -66,7 +66,7 @@ spec:
           tolerationSeconds: 22
           value: test
     querier:
-      replicas: 30
+      replicas: 3
       tolerations:
         - effect: test
           key: test
@@ -79,7 +79,7 @@ spec:
           tolerationSeconds: 73
           value: test
     queryFrontend:
-      replicas: 47
+      replicas: 3
       tolerations:
         - effect: test
           key: test

--- a/internal/manifests/config.go
+++ b/internal/manifests/config.go
@@ -85,9 +85,9 @@ func configForSize(sizeType lokiv1beta1.LokiStackSizeType) lokiv1beta1.LokiStack
 					MaxStreamsPerUser:  25000,
 				},
 				QueryLimits: lokiv1beta1.QueryLimitSpec{
-					MaxEntriesPerQuery: 0,
-					MaxChunksPerQuery:  0,
-					MaxQuerySeries:     0,
+					MaxEntriesLimitPerQuery: 0,
+					MaxChunksPerQuery:       0,
+					MaxQuerySeries:          0,
 				},
 			},
 		},

--- a/internal/manifests/config_test.go
+++ b/internal/manifests/config_test.go
@@ -32,7 +32,6 @@ func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {
 	assert.JSONEq(t, string(expected), string(actual))
 }
 
-
 func randomConfigOptions() manifests.Options {
 	return manifests.Options{
 		Name:      uuid.New().String(),
@@ -43,22 +42,22 @@ func randomConfigOptions() manifests.Options {
 			Storage:           lokiv1beta1.ObjectStorageSpec{},
 			StorageClassName:  uuid.New().String(),
 			ReplicationFactor: rand.Int31(),
-			Limits:            lokiv1beta1.LimitsSpec{
-				Global:  lokiv1beta1.LimitsTemplateSpec{
+			Limits: lokiv1beta1.LimitsSpec{
+				Global: lokiv1beta1.LimitsTemplateSpec{
 					IngestionLimits: lokiv1beta1.IngestionLimitSpec{
 						IngestionRate:           rand.Int31(),
 						IngestionBurstSize:      rand.Int31(),
 						MaxLabelLength:          rand.Int31(),
 						MaxLabelValueLength:     rand.Int31(),
-						MaxLabelsPerSeries:      rand.Int31(),
+						MaxLabelNamesPerSeries:  rand.Int31(),
 						MaxStreamsPerUser:       rand.Int31(),
 						MaxGlobalStreamsPerUser: rand.Int31(),
 						MaxLineSize:             rand.Int31(),
 					},
-					QueryLimits:     lokiv1beta1.QueryLimitSpec{
-						MaxEntriesPerQuery: rand.Int31(),
-						MaxChunksPerQuery:  rand.Int31(),
-						MaxQuerySeries:     rand.Int31(),
+					QueryLimits: lokiv1beta1.QueryLimitSpec{
+						MaxEntriesLimitPerQuery: rand.Int31(),
+						MaxChunksPerQuery:       rand.Int31(),
+						MaxQuerySeries:          rand.Int31(),
 					},
 				},
 				Tenants: map[string]lokiv1beta1.LimitsTemplateSpec{
@@ -68,26 +67,26 @@ func randomConfigOptions() manifests.Options {
 							IngestionBurstSize:      rand.Int31(),
 							MaxLabelLength:          rand.Int31(),
 							MaxLabelValueLength:     rand.Int31(),
-							MaxLabelsPerSeries:      rand.Int31(),
+							MaxLabelNamesPerSeries:  rand.Int31(),
 							MaxStreamsPerUser:       rand.Int31(),
 							MaxGlobalStreamsPerUser: rand.Int31(),
 							MaxLineSize:             rand.Int31(),
 						},
-						QueryLimits:     lokiv1beta1.QueryLimitSpec{
-							MaxEntriesPerQuery: rand.Int31(),
-							MaxChunksPerQuery:  rand.Int31(),
-							MaxQuerySeries:     rand.Int31(),
+						QueryLimits: lokiv1beta1.QueryLimitSpec{
+							MaxEntriesLimitPerQuery: rand.Int31(),
+							MaxChunksPerQuery:       rand.Int31(),
+							MaxQuerySeries:          rand.Int31(),
 						},
 					},
 				},
 			},
-			Template:          lokiv1beta1.LokiTemplateSpec{
-				Compactor:     lokiv1beta1.LokiComponentSpec{
-					Replicas:     rand.Int31(),
+			Template: lokiv1beta1.LokiTemplateSpec{
+				Compactor: lokiv1beta1.LokiComponentSpec{
+					Replicas: rand.Int31(),
 					NodeSelector: map[string]string{
 						uuid.New().String(): uuid.New().String(),
 					},
-					Tolerations:  []corev1.Toleration{
+					Tolerations: []corev1.Toleration{
 						{
 							Key:               uuid.New().String(),
 							Operator:          corev1.TolerationOpEqual,
@@ -97,12 +96,12 @@ func randomConfigOptions() manifests.Options {
 						},
 					},
 				},
-				Distributor:   lokiv1beta1.LokiComponentSpec{
-					Replicas:     rand.Int31(),
+				Distributor: lokiv1beta1.LokiComponentSpec{
+					Replicas: rand.Int31(),
 					NodeSelector: map[string]string{
 						uuid.New().String(): uuid.New().String(),
 					},
-					Tolerations:  []corev1.Toleration{
+					Tolerations: []corev1.Toleration{
 						{
 							Key:               uuid.New().String(),
 							Operator:          corev1.TolerationOpEqual,
@@ -112,12 +111,12 @@ func randomConfigOptions() manifests.Options {
 						},
 					},
 				},
-				Ingester:      lokiv1beta1.LokiComponentSpec{
-					Replicas:     rand.Int31(),
+				Ingester: lokiv1beta1.LokiComponentSpec{
+					Replicas: rand.Int31(),
 					NodeSelector: map[string]string{
 						uuid.New().String(): uuid.New().String(),
 					},
-					Tolerations:  []corev1.Toleration{
+					Tolerations: []corev1.Toleration{
 						{
 							Key:               uuid.New().String(),
 							Operator:          corev1.TolerationOpEqual,
@@ -127,12 +126,12 @@ func randomConfigOptions() manifests.Options {
 						},
 					},
 				},
-				Querier:       lokiv1beta1.LokiComponentSpec{
-					Replicas:     rand.Int31(),
+				Querier: lokiv1beta1.LokiComponentSpec{
+					Replicas: rand.Int31(),
 					NodeSelector: map[string]string{
 						uuid.New().String(): uuid.New().String(),
 					},
-					Tolerations:  []corev1.Toleration{
+					Tolerations: []corev1.Toleration{
 						{
 							Key:               uuid.New().String(),
 							Operator:          corev1.TolerationOpEqual,
@@ -143,11 +142,11 @@ func randomConfigOptions() manifests.Options {
 					},
 				},
 				QueryFrontend: lokiv1beta1.LokiComponentSpec{
-					Replicas:     rand.Int31(),
+					Replicas: rand.Int31(),
 					NodeSelector: map[string]string{
 						uuid.New().String(): uuid.New().String(),
 					},
-					Tolerations:  []corev1.Toleration{
+					Tolerations: []corev1.Toleration{
 						{
 							Key:               uuid.New().String(),
 							Operator:          corev1.TolerationOpEqual,

--- a/internal/manifests/internal/config/loki-config.yaml
+++ b/internal/manifests/internal/config/loki-config.yaml
@@ -49,12 +49,12 @@ limits_config:
   max_query_length: 12000h
   max_label_name_length: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelLength }}
   max_label_value_length: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelValueLength }}
-  max_labels_per_series: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelsPerSeries }}
+  max_label_names_per_series: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelNamesPerSeries }}
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_query_parallelism: 32
   max_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxStreamsPerUser }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
-  max_entries_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesPerQuery }}
+  max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
   reject_old_samples: true
   reject_old_samples_max_age: 24h
 memberlist:


### PR DESCRIPTION
This PR provides a set of small fixes to make the default CSV sample from `config/samples` usable for local deployments:
- Fix typos in Loki config options: `MaxEntriesPerQuery` -> MaxEntriesLimitPerQuery`, `MaxLabelsPerSeries` -> `MaxLabelNamesPerSeries`
- Pin sample `size` to `OneXSmall`
- Pin storage class to `standard`
- Pin development overlay to use namespace `default` instead of `openshift-logging`. This enabled deployments on kind w/o the requirement to create `openshift-logging` manually.