### PR TITLE
Add missing manifests tests

### DIFF
--- a/internal/manifests/compactor_test.go
+++ b/internal/manifests/compactor_test.go
@@ -1,0 +1,31 @@
+package manifests_test
+
+import (
+	"testing"
+
+	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
+	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
+	// You must set the .spec.selector field of a StatefulSet to match the labels of
+	// its .spec.template.metadata.labels. Prior to Kubernetes 1.8, the
+	// .spec.selector field was defaulted when omitted. In 1.8 and later versions,
+	// failing to specify a matching Pod Selector will result in a validation error
+	// during StatefulSet creation.
+	// See https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector
+	ss := manifests.NewCompactorStatefulSet(manifests.Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+		Stack: lokiv1beta1.LokiStackSpec{
+			StorageClassName: "standard",
+		},
+	})
+
+	l := ss.Spec.Template.GetObjectMeta().GetLabels()
+	for key, value := range ss.Spec.Selector.MatchLabels {
+		require.Contains(t, l, key)
+		require.Equal(t, l[key], value)
+	}
+}

--- a/internal/manifests/distributor_test.go
+++ b/internal/manifests/distributor_test.go
@@ -1,0 +1,21 @@
+package manifests_test
+
+import (
+	"testing"
+
+	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
+	ss := manifests.NewDistributorDeployment(manifests.Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+	})
+
+	l := ss.Spec.Template.GetObjectMeta().GetLabels()
+	for key, value := range ss.Spec.Selector.MatchLabels {
+		require.Contains(t, l, key)
+		require.Equal(t, l[key], value)
+	}
+}

--- a/internal/manifests/mutate_test.go
+++ b/internal/manifests/mutate_test.go
@@ -1,8 +1,9 @@
-package manifests
+package manifests_test
 
 import (
 	"testing"
 
+	"github.com/ViaQ/loki-operator/internal/manifests"
 	"github.com/stretchr/testify/require"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -35,7 +36,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 		},
 	}
 
-	f := MutateFuncFor(got, want)
+	f := manifests.MutateFuncFor(got, want)
 	err := f()
 	require.NoError(t, err)
 
@@ -47,7 +48,7 @@ func TestGetMutateFunc_MutateObjectMeta(t *testing.T) {
 func TestGetMutateFunc_ReturnErrOnNotSupportedType(t *testing.T) {
 	got := &corev1.ServiceAccount{}
 	want := &corev1.ServiceAccount{}
-	f := MutateFuncFor(got, want)
+	f := manifests.MutateFuncFor(got, want)
 
 	require.Error(t, f())
 }
@@ -63,7 +64,7 @@ func TestGetMutateFunc_MutateConfigMap(t *testing.T) {
 		BinaryData: map[string][]byte{"btest": []byte("btestss")},
 	}
 
-	f := MutateFuncFor(got, want)
+	f := manifests.MutateFuncFor(got, want)
 	err := f()
 	require.NoError(t, err)
 
@@ -112,7 +113,7 @@ func TestGetMutateFunc_MutateServiceSpec(t *testing.T) {
 		},
 	}
 
-	f := MutateFuncFor(got, want)
+	f := manifests.MutateFuncFor(got, want)
 	err := f()
 	require.NoError(t, err)
 
@@ -233,7 +234,7 @@ func TestGeMutateFunc_MutateDeploymentSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := MutateFuncFor(tst.got, tst.want)
+			f := manifests.MutateFuncFor(tst.got, tst.want)
 			err := f()
 			require.NoError(t, err)
 
@@ -390,7 +391,7 @@ func TestGeMutateFunc_MutateStatefulSetSpec(t *testing.T) {
 		tst := tst
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
-			f := MutateFuncFor(tst.got, tst.want)
+			f := manifests.MutateFuncFor(tst.got, tst.want)
 			err := f()
 			require.NoError(t, err)
 

--- a/internal/manifests/query-frontend_test.go
+++ b/internal/manifests/query-frontend_test.go
@@ -1,0 +1,21 @@
+package manifests_test
+
+import (
+	"testing"
+
+	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewQueryFrontendDeployment_SelectorMatchesLabels(t *testing.T) {
+	ss := manifests.NewQueryFrontendDeployment(manifests.Options{
+		Name:      "abcd",
+		Namespace: "efgh",
+	})
+
+	l := ss.Spec.Template.GetObjectMeta().GetLabels()
+	for key, value := range ss.Spec.Selector.MatchLabels {
+		require.Contains(t, l, key)
+		require.Equal(t, l[key], value)
+	}
+}

--- a/internal/manifests/service_test.go
+++ b/internal/manifests/service_test.go
@@ -136,6 +136,13 @@ func TestServicesMatchLabels(t *testing.T) {
 				NewQueryFrontendHTTPService(opt.Name),
 			},
 		},
+		{
+			Object: NewCompactorStatefulSet(opt),
+			Services: []*corev1.Service{
+				NewCompactorGRPCService(opt),
+				NewCompactorHTTPService(opt),
+			},
+		},
 	}
 
 	for _, tst := range table {


### PR DESCRIPTION
This PR adds some tests for missing labels checks for `Spec.Selector` and `Spec.Template.Labels` for newly introduced components and for existing deployments