### PR TITLE
Streamline API terms based on enhancement proposal

### DIFF
--- a/api/v1beta1/lokistack_types.go
+++ b/api/v1beta1/lokistack_types.go
@@ -24,6 +24,21 @@ import (
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
+// ManagementStateType defines the type for CR management states.
+//
+// +kubebuilder:validation:Enum=Managed;Unmanaged
+type ManagementStateType string
+
+const (
+	// ManagementStateManaged when the LokiStack custom resource should be
+	// reconciled by the operator.
+	ManagementStateManaged ManagementStateType = "Managed"
+
+	// ManagementStateUnmanaged when the LokiStack custom resource should not be
+	// reconciled by the operator.
+	ManagementStateUnmanaged ManagementStateType = "Unmanaged"
+)
+
 // LokiStackSizeType declares the type for loki cluster scale outs.
 //
 // +kubebuilder:validation:Enum=SizeOneXExtraSmall;SizeOneXSmall;SizeOneXMedium
@@ -117,10 +132,6 @@ type ObjectStorageSecretSpec struct {
 // ObjectStorageSpec defines the requirements to access the object
 // storage bucket to persist logs by the ingester component.
 type ObjectStorageSpec struct {
-
-	// URL of the object storage to store logs.
-	URL string `json:"url,omitempty"`
-
 	// Secret for object storage authentication.
 	// Name of a secret in the same namespace as the cluster logging operator.
 	//
@@ -183,17 +194,17 @@ type IngestionLimitSpec struct {
 	// +optional
 	MaxLabelNamesPerSeries int32 `json:"maxLabelNamesPerSeries,omitempty"`
 
-	// MaxStreamsPerUser defines the maximum number of active streams
-	// per user, per ingester.
+	// MaxStreamsPerTenant defines the maximum number of active streams
+	// per tenant, per ingester.
 	//
 	// +optional
-	MaxStreamsPerUser int32 `json:"maxStreamsPerUser,omitempty"`
+	MaxStreamsPerTenant int32 `json:"maxStreamsPerTenant,omitempty"`
 
-	// MaxGlobalStreamsPerUser defines the maximum number of active streams
-	// per user, across the cluster.
+	// MaxGlobalStreamsPerTenant defines the maximum number of active streams
+	// per tenant, across the cluster.
 	//
 	// +optional
-	MaxGlobalStreamsPerUser int32 `json:"maxGlobalStreamsPerUser,omitempty"`
+	MaxGlobalStreamsPerTenant int32 `json:"maxGlobalStreamsPerTenant,omitempty"`
 
 	// MaxLineSize defines the aximum line size on ingestion path. Units in Bytes.
 	//
@@ -232,6 +243,14 @@ type LimitsSpec struct {
 // LokiStackSpec defines the desired state of LokiStack
 type LokiStackSpec struct {
 
+	// ManagementState defines if the CR should be managed by the operator or not.
+	// Default is managed.
+	//
+	// +required
+	// +kubebuilder:default:=Managed
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Management State"
+	ManagementState ManagementStateType `json:"managementState,omitempty"`
+
 	// Size defines one of the support Loki deployment scale out sizes.
 	//
 	// +required
@@ -251,6 +270,8 @@ type LokiStackSpec struct {
 	// ReplicationFactor defines the policy for log stream replication.
 	//
 	// +required
+	// +kubebuilder:validation:Minimum:=1
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Replication Factor"
 	ReplicationFactor int32 `json:"replicationFactor,omitempty"`
 
 	// Limits defines the limits to be applied to log stream processing.

--- a/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -16,12 +16,12 @@ metadata:
                 "ingestion": {
                   "ingestionBurstSize": 90,
                   "ingestionRate": 60,
-                  "maxGlobalStreamsPerUser": 83,
+                  "maxGlobalStreamsPerTenant": 83,
                   "maxLabelLength": 40,
                   "maxLabelNamesPerSeries": 45,
                   "maxLabelValueLength": 79,
                   "maxLineSize": 74,
-                  "maxStreamsPerUser": 35
+                  "maxStreamsPerTenant": 35
                 },
                 "queries": {
                   "maxChunksPerQuery": 90,
@@ -31,12 +31,11 @@ metadata:
               }
             },
             "replicationFactor": 2,
-            "size": "OneXSmall",
+            "size": "SizeOneXSmall",
             "storage": {
               "secret": {
                 "name": "test"
-              },
-              "url": "test"
+              }
             },
             "storageClassName": "standard",
             "template": {
@@ -189,6 +188,12 @@ spec:
         name: ""
         version: v1
       specDescriptors:
+      - description: ManagementState defines if the CR should be managed by the operator or not. Default is managed.
+        displayName: Management State
+        path: managementState
+      - description: ReplicationFactor defines the policy for log stream replication.
+        displayName: Replication Factor
+        path: replicationFactor
       - description: Size defines one of the support Loki deployment scale out sizes.
         displayName: Loki Stack Size
         path: size

--- a/bundle/manifests/loki.openshift.io_lokistacks.yaml
+++ b/bundle/manifests/loki.openshift.io_lokistacks.yaml
@@ -55,8 +55,8 @@ spec:
                             description: IngestionRate defines the sample size per second. Units MB.
                             format: int32
                             type: integer
-                          maxGlobalStreamsPerUser:
-                            description: MaxGlobalStreamsPerUser defines the maximum number of active streams per user, across the cluster.
+                          maxGlobalStreamsPerTenant:
+                            description: MaxGlobalStreamsPerTenant defines the maximum number of active streams per tenant, across the cluster.
                             format: int32
                             type: integer
                           maxLabelLength:
@@ -75,8 +75,8 @@ spec:
                             description: MaxLineSize defines the aximum line size on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
-                          maxStreamsPerUser:
-                            description: MaxStreamsPerUser defines the maximum number of active streams per user, per ingester.
+                          maxStreamsPerTenant:
+                            description: MaxStreamsPerTenant defines the maximum number of active streams per tenant, per ingester.
                             format: int32
                             type: integer
                         type: object
@@ -112,8 +112,8 @@ spec:
                               description: IngestionRate defines the sample size per second. Units MB.
                               format: int32
                               type: integer
-                            maxGlobalStreamsPerUser:
-                              description: MaxGlobalStreamsPerUser defines the maximum number of active streams per user, across the cluster.
+                            maxGlobalStreamsPerTenant:
+                              description: MaxGlobalStreamsPerTenant defines the maximum number of active streams per tenant, across the cluster.
                               format: int32
                               type: integer
                             maxLabelLength:
@@ -132,8 +132,8 @@ spec:
                               description: MaxLineSize defines the aximum line size on ingestion path. Units in Bytes.
                               format: int32
                               type: integer
-                            maxStreamsPerUser:
-                              description: MaxStreamsPerUser defines the maximum number of active streams per user, per ingester.
+                            maxStreamsPerTenant:
+                              description: MaxStreamsPerTenant defines the maximum number of active streams per tenant, per ingester.
                               format: int32
                               type: integer
                           type: object
@@ -157,16 +157,24 @@ spec:
                     description: Tenants defines the limits applied per tenant.
                     type: object
                 type: object
+              managementState:
+                default: Managed
+                description: ManagementState defines if the CR should be managed by the operator or not. Default is managed.
+                enum:
+                - Managed
+                - Unmanaged
+                type: string
               replicationFactor:
                 description: ReplicationFactor defines the policy for log stream replication.
                 format: int32
+                minimum: 1
                 type: integer
               size:
                 description: Size defines one of the support Loki deployment scale out sizes.
                 enum:
-                - OneXExtraSmallSize
-                - OneXSmall
-                - OneXMedium
+                - SizeOneXExtraSmall
+                - SizeOneXSmall
+                - SizeOneXMedium
                 type: string
               storage:
                 description: Storage defines the spec for the object storage endpoint to store logs.
@@ -180,9 +188,6 @@ spec:
                     required:
                     - name
                     type: object
-                  url:
-                    description: URL of the object storage to store logs.
-                    type: string
                 type: object
               storageClassName:
                 description: Storage class name defines the storage class for ingester/querier PVCs.

--- a/config/crd/bases/loki.openshift.io_lokistacks.yaml
+++ b/config/crd/bases/loki.openshift.io_lokistacks.yaml
@@ -62,9 +62,9 @@ spec:
                               second. Units MB.
                             format: int32
                             type: integer
-                          maxGlobalStreamsPerUser:
-                            description: MaxGlobalStreamsPerUser defines the maximum
-                              number of active streams per user, across the cluster.
+                          maxGlobalStreamsPerTenant:
+                            description: MaxGlobalStreamsPerTenant defines the maximum
+                              number of active streams per tenant, across the cluster.
                             format: int32
                             type: integer
                           maxLabelLength:
@@ -87,9 +87,9 @@ spec:
                               on ingestion path. Units in Bytes.
                             format: int32
                             type: integer
-                          maxStreamsPerUser:
-                            description: MaxStreamsPerUser defines the maximum number
-                              of active streams per user, per ingester.
+                          maxStreamsPerTenant:
+                            description: MaxStreamsPerTenant defines the maximum number
+                              of active streams per tenant, per ingester.
                             format: int32
                             type: integer
                         type: object
@@ -135,9 +135,9 @@ spec:
                                 second. Units MB.
                               format: int32
                               type: integer
-                            maxGlobalStreamsPerUser:
-                              description: MaxGlobalStreamsPerUser defines the maximum
-                                number of active streams per user, across the cluster.
+                            maxGlobalStreamsPerTenant:
+                              description: MaxGlobalStreamsPerTenant defines the maximum
+                                number of active streams per tenant, across the cluster.
                               format: int32
                               type: integer
                             maxLabelLength:
@@ -161,9 +161,9 @@ spec:
                                 on ingestion path. Units in Bytes.
                               format: int32
                               type: integer
-                            maxStreamsPerUser:
-                              description: MaxStreamsPerUser defines the maximum number
-                                of active streams per user, per ingester.
+                            maxStreamsPerTenant:
+                              description: MaxStreamsPerTenant defines the maximum
+                                number of active streams per tenant, per ingester.
                               format: int32
                               type: integer
                           type: object
@@ -192,9 +192,18 @@ spec:
                     description: Tenants defines the limits applied per tenant.
                     type: object
                 type: object
+              managementState:
+                default: Managed
+                description: ManagementState defines if the CR should be managed by
+                  the operator or not. Default is managed.
+                enum:
+                - Managed
+                - Unmanaged
+                type: string
               replicationFactor:
                 description: ReplicationFactor defines the policy for log stream replication.
                 format: int32
+                minimum: 1
                 type: integer
               size:
                 description: Size defines one of the support Loki deployment scale
@@ -219,9 +228,6 @@ spec:
                     required:
                     - name
                     type: object
-                  url:
-                    description: URL of the object storage to store logs.
-                    type: string
                 type: object
               storageClassName:
                 description: Storage class name defines the storage class for ingester/querier

--- a/config/manifests/bases/loki-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/loki-operator.clusterserviceversion.yaml
@@ -51,6 +51,12 @@ spec:
         name: ""
         version: v1
       specDescriptors:
+      - description: ManagementState defines if the CR should be managed by the operator or not. Default is managed.
+        displayName: Management State
+        path: managementState
+      - description: ReplicationFactor defines the policy for log stream replication.
+        displayName: Replication Factor
+        path: replicationFactor
       - description: Size defines one of the support Loki deployment scale out sizes.
         displayName: Loki Stack Size
         path: size

--- a/config/samples/loki_v1beta1_lokistack.yaml
+++ b/config/samples/loki_v1beta1_lokistack.yaml
@@ -8,12 +8,12 @@ spec:
       ingestion:
         ingestionBurstSize: 90
         ingestionRate: 60
-        maxGlobalStreamsPerUser: 83
+        maxGlobalStreamsPerTenant: 83
         maxLabelLength: 40
         maxLabelValueLength: 79
         maxLabelNamesPerSeries: 45
         maxLineSize: 74
-        maxStreamsPerUser: 35
+        maxStreamsPerTenant: 35
       queries:
         maxChunksPerQuery: 90
         maxEntriesLimitPerQuery: 8

--- a/controllers/internal/management/state/state.go
+++ b/controllers/internal/management/state/state.go
@@ -1,0 +1,30 @@
+package state
+
+import (
+	"context"
+
+	"github.com/ViaQ/logerr/kverrors"
+	"github.com/ViaQ/logerr/log"
+	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
+	"github.com/ViaQ/loki-operator/internal/external/k8s"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+// IsManaged checks if the custom resource is configured with ManagementState Managed.
+func IsManaged(ctx context.Context, req ctrl.Request, k k8s.Client) (bool, error) {
+	ll := log.WithValues("lokistack", req.NamespacedName)
+
+	var stack lokiv1beta1.LokiStack
+	if err := k.Get(ctx, req.NamespacedName, &stack); err != nil {
+		if apierrors.IsNotFound(err) {
+			// maybe the user deleted it before we could react? Either way this isn't an issue
+			ll.Error(err, "could not find the requested loki stack", "name", req.NamespacedName)
+			return false, nil
+		}
+		return false, kverrors.Wrap(err, "failed to lookup lokistack", "name", req.NamespacedName)
+	}
+	return stack.Spec.ManagementState == lokiv1beta1.ManagementStateManaged, nil
+}

--- a/controllers/internal/management/state/state_test.go
+++ b/controllers/internal/management/state/state_test.go
@@ -1,0 +1,124 @@
+package state_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ViaQ/logerr/kverrors"
+	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
+	"github.com/ViaQ/loki-operator/controllers/internal/management/state"
+	"github.com/ViaQ/loki-operator/internal/external/k8s/k8sfakes"
+	"github.com/stretchr/testify/require"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestIsManaged(t *testing.T) {
+	type test struct {
+		name   string
+		stack  lokiv1beta1.LokiStack
+		wantOk bool
+	}
+
+	k := &k8sfakes.FakeClient{}
+	r := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-stack",
+			Namespace: "some-ns",
+		},
+	}
+	table := []test{
+		{
+			name: "managed",
+			stack: lokiv1beta1.LokiStack{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "LokiStack",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-stack",
+					Namespace: "some-ns",
+					UID:       "b23f9a38-9672-499f-8c29-15ede74d3ece",
+				},
+				Spec: lokiv1beta1.LokiStackSpec{
+					ManagementState: lokiv1beta1.ManagementStateManaged,
+				},
+			},
+			wantOk: true,
+		},
+		{
+			name: "unmanaged",
+			stack: lokiv1beta1.LokiStack{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "LokiStack",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-stack",
+					Namespace: "some-ns",
+					UID:       "b23f9a38-9672-499f-8c29-15ede74d3ece",
+				},
+				Spec: lokiv1beta1.LokiStackSpec{
+					ManagementState: lokiv1beta1.ManagementStateUnmanaged,
+				},
+			},
+		},
+	}
+	for _, tst := range table {
+		tst := tst
+		t.Run(tst.name, func(t *testing.T) {
+			t.Parallel()
+			k.GetStub = func(_ context.Context, _ types.NamespacedName, object client.Object) error {
+				k.SetClientObject(object, &tst.stack)
+				return nil
+			}
+			ok, err := state.IsManaged(context.TODO(), r, k)
+			require.NoError(t, err)
+			require.Equal(t, ok, tst.wantOk)
+		})
+	}
+}
+
+func TestIsManaged_WhenError_ReturnNotManagedWithError(t *testing.T) {
+	type test struct {
+		name     string
+		apierror error
+		wantErr  error
+	}
+
+	badReqErr := apierrors.NewBadRequest("bad request")
+	k := &k8sfakes.FakeClient{}
+	r := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "my-stack",
+			Namespace: "some-ns",
+		},
+	}
+	table := []test{
+		{
+			name:     "stack not found error",
+			apierror: apierrors.NewNotFound(schema.GroupResource{}, "something not found"),
+		},
+		{
+			name:     "any other api error",
+			apierror: badReqErr,
+			wantErr:  kverrors.Wrap(badReqErr, "failed to lookup lokistack", "name", r.NamespacedName),
+		},
+	}
+	for _, tst := range table {
+		tst := tst
+		t.Run(tst.name, func(t *testing.T) {
+			t.Parallel()
+			k.GetStub = func(_ context.Context, _ types.NamespacedName, _ client.Object) error {
+				return tst.apierror
+			}
+			ok, err := state.IsManaged(context.TODO(), r, k)
+			require.Equal(t, tst.wantErr, err)
+			require.False(t, ok)
+		})
+	}
+}

--- a/internal/manifests/config_test.go
+++ b/internal/manifests/config_test.go
@@ -78,14 +78,14 @@ func randomConfigOptions() manifests.Options {
 			Limits: lokiv1beta1.LimitsSpec{
 				Global: lokiv1beta1.LimitsTemplateSpec{
 					IngestionLimits: lokiv1beta1.IngestionLimitSpec{
-						IngestionRate:           rand.Int31(),
-						IngestionBurstSize:      rand.Int31(),
-						MaxLabelLength:          rand.Int31(),
-						MaxLabelValueLength:     rand.Int31(),
-						MaxLabelNamesPerSeries:  rand.Int31(),
-						MaxStreamsPerUser:       rand.Int31(),
-						MaxGlobalStreamsPerUser: rand.Int31(),
-						MaxLineSize:             rand.Int31(),
+						IngestionRate:             rand.Int31(),
+						IngestionBurstSize:        rand.Int31(),
+						MaxLabelLength:            rand.Int31(),
+						MaxLabelValueLength:       rand.Int31(),
+						MaxLabelNamesPerSeries:    rand.Int31(),
+						MaxStreamsPerTenant:       rand.Int31(),
+						MaxGlobalStreamsPerTenant: rand.Int31(),
+						MaxLineSize:               rand.Int31(),
 					},
 					QueryLimits: lokiv1beta1.QueryLimitSpec{
 						MaxEntriesLimitPerQuery: rand.Int31(),
@@ -96,14 +96,14 @@ func randomConfigOptions() manifests.Options {
 				Tenants: map[string]lokiv1beta1.LimitsTemplateSpec{
 					uuid.New().String(): {
 						IngestionLimits: lokiv1beta1.IngestionLimitSpec{
-							IngestionRate:           rand.Int31(),
-							IngestionBurstSize:      rand.Int31(),
-							MaxLabelLength:          rand.Int31(),
-							MaxLabelValueLength:     rand.Int31(),
-							MaxLabelNamesPerSeries:  rand.Int31(),
-							MaxStreamsPerUser:       rand.Int31(),
-							MaxGlobalStreamsPerUser: rand.Int31(),
-							MaxLineSize:             rand.Int31(),
+							IngestionRate:             rand.Int31(),
+							IngestionBurstSize:        rand.Int31(),
+							MaxLabelLength:            rand.Int31(),
+							MaxLabelValueLength:       rand.Int31(),
+							MaxLabelNamesPerSeries:    rand.Int31(),
+							MaxStreamsPerTenant:       rand.Int31(),
+							MaxGlobalStreamsPerTenant: rand.Int31(),
+							MaxLineSize:               rand.Int31(),
 						},
 						QueryLimits: lokiv1beta1.QueryLimitSpec{
 							MaxEntriesLimitPerQuery: rand.Int31(),

--- a/internal/manifests/internal/config/loki-config.yaml
+++ b/internal/manifests/internal/config/loki-config.yaml
@@ -49,14 +49,14 @@ limits_config:
   ingestion_rate_mb: {{ .Stack.Limits.Global.IngestionLimits.IngestionRate }}
   ingestion_rate_strategy: global
   max_cache_freshness_per_query: 10m
-  max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerUser }}
+  max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
   max_query_length: 12000h
   max_label_name_length: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelLength }}
   max_label_value_length: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelValueLength }}
   max_label_names_per_series: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelNamesPerSeries }}
   max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
   max_query_parallelism: 32
-  max_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxStreamsPerUser }}
+  max_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxStreamsPerTenant }}
   max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
   max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
   reject_old_samples: true

--- a/internal/manifests/internal/sizes.go
+++ b/internal/manifests/internal/sizes.go
@@ -139,9 +139,9 @@ var StackSizeTable = map[lokiv1beta1.LokiStackSizeType]lokiv1beta1.LokiStackSpec
 		Limits: lokiv1beta1.LimitsSpec{
 			Global: lokiv1beta1.LimitsTemplateSpec{
 				IngestionLimits: lokiv1beta1.IngestionLimitSpec{
-					IngestionRate:      20,
-					IngestionBurstSize: 10,
-					MaxStreamsPerUser:  25000,
+					IngestionRate:       20,
+					IngestionBurstSize:  10,
+					MaxStreamsPerTenant: 25000,
 				},
 				QueryLimits: lokiv1beta1.QueryLimitSpec{
 					MaxEntriesLimitPerQuery: 0,
@@ -175,9 +175,9 @@ var StackSizeTable = map[lokiv1beta1.LokiStackSizeType]lokiv1beta1.LokiStackSpec
 		Limits: lokiv1beta1.LimitsSpec{
 			Global: lokiv1beta1.LimitsTemplateSpec{
 				IngestionLimits: lokiv1beta1.IngestionLimitSpec{
-					IngestionRate:      20,
-					IngestionBurstSize: 10,
-					MaxStreamsPerUser:  25000,
+					IngestionRate:       20,
+					IngestionBurstSize:  10,
+					MaxStreamsPerTenant: 25000,
 				},
 				QueryLimits: lokiv1beta1.QueryLimitSpec{
 					MaxEntriesLimitPerQuery: 0,
@@ -211,9 +211,9 @@ var StackSizeTable = map[lokiv1beta1.LokiStackSizeType]lokiv1beta1.LokiStackSpec
 		Limits: lokiv1beta1.LimitsSpec{
 			Global: lokiv1beta1.LimitsTemplateSpec{
 				IngestionLimits: lokiv1beta1.IngestionLimitSpec{
-					IngestionRate:      20,
-					IngestionBurstSize: 10,
-					MaxStreamsPerUser:  25000,
+					IngestionRate:       20,
+					IngestionBurstSize:  10,
+					MaxStreamsPerTenant: 25000,
 				},
 				QueryLimits: lokiv1beta1.QueryLimitSpec{
 					MaxEntriesLimitPerQuery: 0,


### PR DESCRIPTION
This PR provides some streamlining fixes based on discussions [here](openshift/enhancements/pull/712):
- Drops separate `URL` field from `ObjectStorageSpec` in favor of using only a `Secret`.
- Renames fields using `perUser` to `perTenant` suffix. Tenant and user are used interchangeably in the Loki configuration. So we stick with tenant as the major term.
- Add field `ManagementState` defaulting to `Managed`.