### PR TITLE
Provide sane defaults for limits per stack size and loki config

### DIFF
--- a/api/v1beta1/lokistack_types.go
+++ b/api/v1beta1/lokistack_types.go
@@ -191,12 +191,12 @@ type IngestionLimitSpec struct {
 	// +kubebuilder:validation:Optional
 	IngestionBurstSize int32 `json:"ingestionBurstSize,omitempty"`
 
-	// MaxLabelLength defines the maximum number of characters allowed
+	// MaxLabelNameLength defines the maximum number of characters allowed
 	// for label keys in log streams.
 	//
 	// +optional
 	// +kubebuilder:validation:Optional
-	MaxLabelLength int32 `json:"maxLabelLength,omitempty"`
+	MaxLabelNameLength int32 `json:"maxLabelNameLength,omitempty"`
 
 	// MaxLabelValueLength defines the maximum number of characters allowed
 	// for label values in log streams.

--- a/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -11,130 +11,14 @@ metadata:
             "name": "lokistack-sample"
           },
           "spec": {
-            "limits": {
-              "global": {
-                "ingestion": {
-                  "ingestionBurstSize": 90,
-                  "ingestionRate": 60,
-                  "maxGlobalStreamsPerTenant": 83,
-                  "maxLabelLength": 40,
-                  "maxLabelNamesPerSeries": 45,
-                  "maxLabelValueLength": 79,
-                  "maxLineSize": 74,
-                  "maxStreamsPerTenant": 35
-                },
-                "queries": {
-                  "maxChunksPerQuery": 90,
-                  "maxEntriesLimitPerQuery": 8,
-                  "maxQuerySeries": 71
-                }
-              }
-            },
             "replicationFactor": 2,
-            "size": "SizeOneXSmall",
+            "size": "1x.small",
             "storage": {
               "secret": {
                 "name": "test"
               }
             },
-            "storageClassName": "standard",
-            "template": {
-              "compactor": {
-                "replicas": 1,
-                "tolerations": [
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 35,
-                    "value": "test"
-                  },
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 43,
-                    "value": "test"
-                  }
-                ]
-              },
-              "distributor": {
-                "replicas": 3,
-                "tolerations": [
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 72,
-                    "value": "test"
-                  },
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 9,
-                    "value": "test"
-                  }
-                ]
-              },
-              "ingester": {
-                "replicas": 3,
-                "tolerations": [
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 20,
-                    "value": "test"
-                  },
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 22,
-                    "value": "test"
-                  }
-                ]
-              },
-              "querier": {
-                "replicas": 3,
-                "tolerations": [
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 22,
-                    "value": "test"
-                  },
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 73,
-                    "value": "test"
-                  }
-                ]
-              },
-              "queryFrontend": {
-                "replicas": 3,
-                "tolerations": [
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 9,
-                    "value": "test"
-                  },
-                  {
-                    "effect": "test",
-                    "key": "test",
-                    "operator": "test",
-                    "tolerationSeconds": 23,
-                    "value": "test"
-                  }
-                ]
-              }
-            }
+            "storageClassName": "standard"
           }
         }
       ]

--- a/bundle/manifests/loki.openshift.io_lokistacks.yaml
+++ b/bundle/manifests/loki.openshift.io_lokistacks.yaml
@@ -59,8 +59,8 @@ spec:
                             description: MaxGlobalStreamsPerTenant defines the maximum number of active streams per tenant, across the cluster.
                             format: int32
                             type: integer
-                          maxLabelLength:
-                            description: MaxLabelLength defines the maximum number of characters allowed for label keys in log streams.
+                          maxLabelNameLength:
+                            description: MaxLabelNameLength defines the maximum number of characters allowed for label keys in log streams.
                             format: int32
                             type: integer
                           maxLabelNamesPerSeries:
@@ -116,8 +116,8 @@ spec:
                               description: MaxGlobalStreamsPerTenant defines the maximum number of active streams per tenant, across the cluster.
                               format: int32
                               type: integer
-                            maxLabelLength:
-                              description: MaxLabelLength defines the maximum number of characters allowed for label keys in log streams.
+                            maxLabelNameLength:
+                              description: MaxLabelNameLength defines the maximum number of characters allowed for label keys in log streams.
                               format: int32
                               type: integer
                             maxLabelNamesPerSeries:

--- a/config/crd/bases/loki.openshift.io_lokistacks.yaml
+++ b/config/crd/bases/loki.openshift.io_lokistacks.yaml
@@ -67,8 +67,8 @@ spec:
                               number of active streams per tenant, across the cluster.
                             format: int32
                             type: integer
-                          maxLabelLength:
-                            description: MaxLabelLength defines the maximum number
+                          maxLabelNameLength:
+                            description: MaxLabelNameLength defines the maximum number
                               of characters allowed for label keys in log streams.
                             format: int32
                             type: integer
@@ -140,9 +140,10 @@ spec:
                                 number of active streams per tenant, across the cluster.
                               format: int32
                               type: integer
-                            maxLabelLength:
-                              description: MaxLabelLength defines the maximum number
-                                of characters allowed for label keys in log streams.
+                            maxLabelNameLength:
+                              description: MaxLabelNameLength defines the maximum
+                                number of characters allowed for label keys in log
+                                streams.
                               format: int32
                               type: integer
                             maxLabelNamesPerSeries:

--- a/config/samples/loki_v1beta1_lokistack.yaml
+++ b/config/samples/loki_v1beta1_lokistack.yaml
@@ -3,90 +3,9 @@ kind: LokiStack
 metadata:
   name: lokistack-sample
 spec:
-  limits:
-    global:
-      ingestion:
-        ingestionBurstSize: 90
-        ingestionRate: 60
-        maxGlobalStreamsPerTenant: 83
-        maxLabelLength: 40
-        maxLabelValueLength: 79
-        maxLabelNamesPerSeries: 45
-        maxLineSize: 74
-        maxStreamsPerTenant: 35
-      queries:
-        maxChunksPerQuery: 90
-        maxEntriesLimitPerQuery: 8
-        maxQuerySeries: 71
+  size: 1x.small
   replicationFactor: 2
-  size: SizeOneXSmall
   storage:
     secret:
       name: test
   storageClassName: standard
-  template:
-    compactor:
-      replicas: 1
-      tolerations:
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 35
-          value: test
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 43
-          value: test
-    distributor:
-      replicas: 3
-      tolerations:
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 72
-          value: test
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 9
-          value: test
-    ingester:
-      replicas: 3
-      tolerations:
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 20
-          value: test
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 22
-          value: test
-    querier:
-      replicas: 3
-      tolerations:
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 22
-          value: test
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 73
-          value: test
-    queryFrontend:
-      replicas: 3
-      tolerations:
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 9
-          value: test
-        - effect: test
-          key: test
-          operator: test
-          tolerationSeconds: 23
-          value: test

--- a/internal/manifests/build.go
+++ b/internal/manifests/build.go
@@ -30,7 +30,7 @@ func BuildAll(opt Options) ([]client.Object, error) {
 	res = append(res, BuildQuerier(opt)...)
 	res = append(res, BuildCompactor(opt)...)
 	res = append(res, BuildQueryFrontend(opt)...)
-	res = append(res, LokiGossipRingService(opt.Name))
+	res = append(res, BuildLokiGossipRingService(opt.Name))
 
 	return res, nil
 }
@@ -55,6 +55,7 @@ func applyUserOptions(opt Options) (Options, error) {
 		return Options{}, kverrors.Wrap(err, "failed to merge strict defaults")
 	}
 
+	opt.ResourceRequirements = internal.ResourceRequirementsTable[opt.Stack.Size]
 	opt.Stack = *spec
 	return opt, nil
 }

--- a/internal/manifests/compactor.go
+++ b/internal/manifests/compactor.go
@@ -42,8 +42,9 @@ func NewCompactorStatefulSet(opt Options) *appsv1.StatefulSet {
 		},
 		Containers: []corev1.Container{
 			{
-				Image: opt.Image,
-				Name:  "loki-compactor",
+				Image:     opt.Image,
+				Name:      "loki-compactor",
+				Resources: opt.ResourceRequirements.Compactor,
 				Args: []string{
 					"-target=compactor",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),

--- a/internal/manifests/config_test.go
+++ b/internal/manifests/config_test.go
@@ -29,8 +29,7 @@ func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {
 	// that every value is present in the result
 	opts := randomConfigOptions()
 
-	res, err := manifests.ConfigOptions(opts)
-	require.NoError(t, err)
+	res := manifests.ConfigOptions(opts)
 
 	expected, err := json.Marshal(opts.Stack)
 	require.NoError(t, err)
@@ -56,7 +55,7 @@ func randomConfigOptions() manifests.Options {
 					IngestionLimits: &lokiv1beta1.IngestionLimitSpec{
 						IngestionRate:             rand.Int31(),
 						IngestionBurstSize:        rand.Int31(),
-						MaxLabelLength:            rand.Int31(),
+						MaxLabelNameLength:        rand.Int31(),
 						MaxLabelValueLength:       rand.Int31(),
 						MaxLabelNamesPerSeries:    rand.Int31(),
 						MaxStreamsPerTenant:       rand.Int31(),
@@ -74,7 +73,7 @@ func randomConfigOptions() manifests.Options {
 						IngestionLimits: &lokiv1beta1.IngestionLimitSpec{
 							IngestionRate:             rand.Int31(),
 							IngestionBurstSize:        rand.Int31(),
-							MaxLabelLength:            rand.Int31(),
+							MaxLabelNameLength:        rand.Int31(),
 							MaxLabelValueLength:       rand.Int31(),
 							MaxLabelNamesPerSeries:    rand.Int31(),
 							MaxStreamsPerTenant:       rand.Int31(),

--- a/internal/manifests/distributor.go
+++ b/internal/manifests/distributor.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/ViaQ/loki-operator/internal/manifests/internal"
 	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +54,7 @@ func NewDistributorDeployment(opt Options) *appsv1.Deployment {
 			{
 				Image:     opt.Image,
 				Name:      "loki-distributor",
-				Resources: internal.ResourceSizeTable[opt.Stack.Size].Distributor,
+				Resources: opt.ResourceRequirements.Distributor,
 				Args: []string{
 					"-target=distributor",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),

--- a/internal/manifests/ingester.go
+++ b/internal/manifests/ingester.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/ViaQ/loki-operator/internal/manifests/internal"
 	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +43,7 @@ func NewIngesterStatefulSet(opt Options) *appsv1.StatefulSet {
 			{
 				Image:     opt.Image,
 				Name:      "loki-ingester",
-				Resources: internal.ResourceSizeTable[opt.Stack.Size].Ingester,
+				Resources: opt.ResourceRequirements.Ingester,
 				Args: []string{
 					"-target=ingester",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),

--- a/internal/manifests/internal/config/loki-config.yaml
+++ b/internal/manifests/internal/config/loki-config.yaml
@@ -13,14 +13,15 @@ distributor:
       store: memberlist
 frontend:
   downstream_url: {{ .Querier.FQDN }}:{{ .Querier.Port }}
+  tail_proxy_url: {{ .Querier.FQDN }}:{{ .Querier.Port }}
   compress_responses: true
-  max_outstanding_per_tenant: 200
+  max_outstanding_per_tenant: 256
   log_queries_longer_than: 5s
 frontend_worker:
-#  frontend_address: {{ .FrontendWorker.FQDN }}:{{ .FrontendWorker.Port }}
-#  grpc_client_config:
-#    max_send_msg_size: 104857600
-  parallelism: 32
+  frontend_address: {{ .FrontendWorker.FQDN }}:{{ .FrontendWorker.Port }}
+  grpc_client_config:
+    max_send_msg_size: 104857600
+  parallelism: {{ .QueryParallelism.Value }}
 ingester:
   chunk_block_size: 262144
   chunk_encoding: snappy
@@ -31,36 +32,48 @@ ingester:
     heartbeat_period: 5s
     interface_names:
       - eth0
-    join_after: 60s
+    join_after: 30s
     num_tokens: 512
     ring:
       replication_factor: {{ .Stack.ReplicationFactor }}
       heartbeat_timeout: 1m
       kvstore:
         store: memberlist
-  max_transfer_retries: 0
+  max_transfer_retries: 60
 ingester_client:
   grpc_client_config:
     max_recv_msg_size: 67108864
   remote_timeout: 1s
+# NOTE: Keep the order of keys as in Loki docs
+# to enable easy diffs when vendoring newer
+# Loki releases.
+# (See https://grafana.com/docs/loki/latest/configuration/#limits_config)
+#
+# Values for not exposed fields are taken from the grafana/loki production
+# configuration manifests.
+# (See https://github.com/grafana/loki/blob/main/production/ksonnet/loki/config.libsonnet)
 limits_config:
-  enforce_metric_name: false
-  ingestion_burst_size_mb: {{ .Stack.Limits.Global.IngestionLimits.IngestionBurstSize }}
-  ingestion_rate_mb: {{ .Stack.Limits.Global.IngestionLimits.IngestionRate }}
   ingestion_rate_strategy: global
-  max_cache_freshness_per_query: 10m
-  max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
-  max_query_length: 12000h
-  max_label_name_length: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelLength }}
+  ingestion_rate_mb: {{ .Stack.Limits.Global.IngestionLimits.IngestionRate }}
+  ingestion_burst_size_mb: {{ .Stack.Limits.Global.IngestionLimits.IngestionBurstSize }}
+  max_label_name_length: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelNameLength }}
   max_label_value_length: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelValueLength }}
   max_label_names_per_series: {{ .Stack.Limits.Global.IngestionLimits.MaxLabelNamesPerSeries }}
-  max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
-  max_query_parallelism: 32
-  max_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxStreamsPerTenant }}
-  max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
-  max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
   reject_old_samples: true
-  reject_old_samples_max_age: 24h
+  reject_old_samples_max_age: 168h
+  creation_grace_period: 10m
+  enforce_metric_name: false
+  max_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxStreamsPerTenant }}
+  max_line_size: {{ .Stack.Limits.Global.IngestionLimits.MaxLineSize }}
+  max_entries_limit_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxEntriesLimitPerQuery }}
+  max_global_streams_per_user: {{ .Stack.Limits.Global.IngestionLimits.MaxGlobalStreamsPerTenant }}
+  max_chunks_per_query: {{ .Stack.Limits.Global.QueryLimits.MaxChunksPerQuery }}
+  max_query_length: 12000h
+  max_query_parallelism: 16
+  max_query_series: {{ .Stack.Limits.Global.QueryLimits.MaxQuerySeries }}
+  cardinality_limit: 100000
+  max_streams_matchers_per_query: 1000
+  max_cache_freshness_per_query: 10m
 memberlist:
   abort_if_cluster_join_fails: true
   bind_port: {{ .GossipRing.Port }}
@@ -71,11 +84,11 @@ memberlist:
   min_join_backoff: 1s
 querier:
   engine:
-    max_look_back_period: 5m
+    max_look_back_period: 30s
     timeout: 3m
   extra_query_delay: 0s
   query_ingesters_within: 2h
-  query_timeout: 1h
+  query_timeout: 1m
   tail_max_duration: 1h
 query_range:
   align_queries_with_step: true
@@ -83,6 +96,7 @@ query_range:
   max_retries: 5
   results_cache: {}
   split_queries_by_interval: 30m
+  parallelise_shardable_queries: false
 schema_config:
   configs:
     - from: "2020-10-01"

--- a/internal/manifests/internal/config/options.go
+++ b/internal/manifests/internal/config/options.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"math"
+
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
 )
 
@@ -15,6 +17,7 @@ type Options struct {
 	Querier          Address
 	StorageDirectory string
 	ObjectStorage    ObjectStorage
+	QueryParallelism Parallelism
 }
 
 // Address FQDN and port for a k8s service.
@@ -32,4 +35,18 @@ type ObjectStorage struct {
 	Buckets         string
 	AccessKeyID     string
 	AccessKeySecret string
+}
+
+// Parallelism for query processing parallelism
+// and rate limiting.
+type Parallelism struct {
+	QuerierCPULimits      int64
+	QueryFrontendReplicas int32
+}
+
+// Value calculates the floor of the division of
+// querier cpu limits to the query frontend replicas
+// available.
+func (p Parallelism) Value() int32 {
+	return int32(math.Floor(float64(p.QuerierCPULimits) / float64(p.QueryFrontendReplicas)))
 }

--- a/internal/manifests/internal/sizes.go
+++ b/internal/manifests/internal/sizes.go
@@ -6,8 +6,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-// ResourceSizes is a map of component->requests/limits
-type ResourceSizes struct {
+// ResourceRequirements is a map of component->requests/limits
+type ResourceRequirements struct {
 	Querier       corev1.ResourceRequirements
 	Ingester      corev1.ResourceRequirements
 	Distributor   corev1.ResourceRequirements
@@ -15,8 +15,8 @@ type ResourceSizes struct {
 	Compactor     corev1.ResourceRequirements
 }
 
-// ResourceSizeTable defines the default resource requests and limits for each size
-var ResourceSizeTable = map[lokiv1beta1.LokiStackSizeType]ResourceSizes{
+// ResourceRequirementsTable defines the default resource requests and limits for each size
+var ResourceRequirementsTable = map[lokiv1beta1.LokiStackSizeType]ResourceRequirements{
 	lokiv1beta1.SizeOneXExtraSmall: {
 		Querier: corev1.ResourceRequirements{
 			Limits: nil,
@@ -139,14 +139,20 @@ var StackSizeTable = map[lokiv1beta1.LokiStackSizeType]lokiv1beta1.LokiStackSpec
 		Limits: &lokiv1beta1.LimitsSpec{
 			Global: &lokiv1beta1.LimitsTemplateSpec{
 				IngestionLimits: &lokiv1beta1.IngestionLimitSpec{
-					IngestionRate:       20,
-					IngestionBurstSize:  10,
-					MaxStreamsPerTenant: 25000,
+					// Defaults from Loki docs
+					IngestionRate:          4,
+					IngestionBurstSize:     6,
+					MaxStreamsPerTenant:    10000,
+					MaxLabelNameLength:     1024,
+					MaxLabelValueLength:    2048,
+					MaxLabelNamesPerSeries: 30,
+					MaxLineSize:            256000,
 				},
 				QueryLimits: &lokiv1beta1.QueryLimitSpec{
-					MaxEntriesLimitPerQuery: 0,
-					MaxChunksPerQuery:       0,
-					MaxQuerySeries:          0,
+					// Defaults from Loki docs
+					MaxEntriesLimitPerQuery: 5000,
+					MaxChunksPerQuery:       2000000,
+					MaxQuerySeries:          500,
 				},
 			},
 		},
@@ -175,14 +181,22 @@ var StackSizeTable = map[lokiv1beta1.LokiStackSizeType]lokiv1beta1.LokiStackSpec
 		Limits: &lokiv1beta1.LimitsSpec{
 			Global: &lokiv1beta1.LimitsTemplateSpec{
 				IngestionLimits: &lokiv1beta1.IngestionLimitSpec{
-					IngestionRate:       20,
-					IngestionBurstSize:  10,
-					MaxStreamsPerTenant: 25000,
+					// Custom for 1x.small
+					IngestionRate:             10,
+					IngestionBurstSize:        20,
+					MaxStreamsPerTenant:       10000,
+					MaxGlobalStreamsPerTenant: 10000,
+					// Defaults from Loki docs
+					MaxLabelNameLength:     1024,
+					MaxLabelValueLength:    2048,
+					MaxLabelNamesPerSeries: 30,
+					MaxLineSize:            256000,
 				},
 				QueryLimits: &lokiv1beta1.QueryLimitSpec{
-					MaxEntriesLimitPerQuery: 0,
-					MaxChunksPerQuery:       0,
-					MaxQuerySeries:          0,
+					// Defaults from Loki docs
+					MaxEntriesLimitPerQuery: 5000,
+					MaxChunksPerQuery:       2000000,
+					MaxQuerySeries:          500,
 				},
 			},
 		},
@@ -211,14 +225,22 @@ var StackSizeTable = map[lokiv1beta1.LokiStackSizeType]lokiv1beta1.LokiStackSpec
 		Limits: &lokiv1beta1.LimitsSpec{
 			Global: &lokiv1beta1.LimitsTemplateSpec{
 				IngestionLimits: &lokiv1beta1.IngestionLimitSpec{
-					IngestionRate:       20,
-					IngestionBurstSize:  10,
-					MaxStreamsPerTenant: 25000,
+					// Custom for 1x.medium
+					IngestionRate:             10,
+					IngestionBurstSize:        20,
+					MaxStreamsPerTenant:       25000,
+					MaxGlobalStreamsPerTenant: 25000,
+					// Defaults from Loki docs
+					MaxLabelNameLength:     1024,
+					MaxLabelValueLength:    2048,
+					MaxLabelNamesPerSeries: 30,
+					MaxLineSize:            256000,
 				},
 				QueryLimits: &lokiv1beta1.QueryLimitSpec{
-					MaxEntriesLimitPerQuery: 0,
-					MaxChunksPerQuery:       0,
-					MaxQuerySeries:          0,
+					// Defaults from Loki docs
+					MaxEntriesLimitPerQuery: 5000,
+					MaxChunksPerQuery:       2000000,
+					MaxQuerySeries:          500,
 				},
 			},
 		},

--- a/internal/manifests/memberlist.go
+++ b/internal/manifests/memberlist.go
@@ -7,8 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// LokiGossipRingService creates a k8s service for the gossip/memberlist members of the cluster
-func LokiGossipRingService(stackName string) *corev1.Service {
+// BuildLokiGossipRingService creates a k8s service for the gossip/memberlist members of the cluster
+func BuildLokiGossipRingService(stackName string) *corev1.Service {
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",

--- a/internal/manifests/options.go
+++ b/internal/manifests/options.go
@@ -2,6 +2,7 @@ package manifests
 
 import (
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
+	"github.com/ViaQ/loki-operator/internal/manifests/internal"
 )
 
 // Options is a set of configuration values to use when building manifests such as resource sizes, etc.
@@ -12,7 +13,8 @@ type Options struct {
 	Image      string
 	ConfigSHA1 string
 
-	Stack lokiv1beta1.LokiStackSpec
+	Stack                lokiv1beta1.LokiStackSpec
+	ResourceRequirements internal.ResourceRequirements
 
 	ObjectStorage ObjectStorage
 }

--- a/internal/manifests/querier.go
+++ b/internal/manifests/querier.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/ViaQ/loki-operator/internal/manifests/internal"
 	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -44,7 +43,7 @@ func NewQuerierStatefulSet(opt Options) *appsv1.StatefulSet {
 			{
 				Image:     opt.Image,
 				Name:      "loki-querier",
-				Resources: internal.ResourceSizeTable[opt.Stack.Size].Querier,
+				Resources: opt.ResourceRequirements.Querier,
 				Args: []string{
 					"-target=querier",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),

--- a/internal/manifests/query-frontend.go
+++ b/internal/manifests/query-frontend.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/ViaQ/loki-operator/internal/manifests/internal"
 	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +48,7 @@ func NewQueryFrontendDeployment(opt Options) *appsv1.Deployment {
 			{
 				Image:     opt.Image,
 				Name:      "loki-query-frontend",
-				Resources: internal.ResourceSizeTable[opt.Stack.Size].QueryFrontend,
+				Resources: opt.ResourceRequirements.QueryFrontend,
 				Args: []string{
 					"-target=query-frontend",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),


### PR DESCRIPTION
The following PR provides a set of sane defaults for `limits_config` and the loki configuration in general based on upstream production configuration, i.e.:
- Limits per stack size are provided based upon our production configuration from [rhobs/configuration](https://github.com/rhobs/configuration/blob/main/resources/services/observatorium-logs-template.yaml#L514)
- Hardcoded limits are provided for all stack based on [Loki docs](https://grafana.com/docs/loki/latest/configuration/#limits_config) and [Loki Production Config](https://github.com/grafana/loki/blob/main/production/ksonnet/loki/config.libsonnet)

Additional small fixes in `loki-config.yaml` for:
- Missing `frontend_worker` configuration to enable back-channel communication from the querier to the query-frontend
- Rename API field `MaxLabelLength` to `MaxLabelNameLength` to align with loki's config parameter `max_label_name_length`
- Provide calculated defaults for `frontend_worker.parallelism` based on the available Querier CPU requests and query frontend replica (More info see [here](https://github.com/grafana/loki/blob/main/production/ksonnet/loki/config.libsonnet#L147))
- Provide default `frontend_worker.tail_proxy_url` to enable Tail calls through the query-frontend.
- Set `max_outstanding_per_tenant` on query-frontend to `256` as a limit before returning `429` status code (More info see [here](https://github.com/grafana/loki/blob/main/production/ksonnet/loki/config.libsonnet#L143)
- Set ingester memberlist retries to `60` and `join_after` to `30s` (More info see [here](https://github.com/grafana/loki/blob/main/production/ksonnet/loki/config.libsonnet#L195)