### PR TITLE
Add support for runtime config

### DIFF
--- a/internal/manifests/build.go
+++ b/internal/manifests/build.go
@@ -18,11 +18,11 @@ func BuildAll(opt Options) ([]client.Object, error) {
 		return nil, err
 	}
 
-	cm, sha1, err := LokiConfigMap(opt)
+	cm, sha1C, err := LokiConfigMap(opt)
 	if err != nil {
 		return nil, err
 	}
-	opt.ConfigSHA1 = sha1
+	opt.ConfigSHA1 = sha1C
 
 	res = append(res, cm)
 	res = append(res, BuildDistributor(opt)...)

--- a/internal/manifests/compactor.go
+++ b/internal/manifests/compactor.go
@@ -48,6 +48,7 @@ func NewCompactorStatefulSet(opt Options) *appsv1.StatefulSet {
 				Args: []string{
 					"-target=compactor",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
+					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{

--- a/internal/manifests/config.go
+++ b/internal/manifests/config.go
@@ -13,17 +13,17 @@ import (
 // LokiConfigMap creates the single configmap containing the loki configuration for the whole cluster
 func LokiConfigMap(opt Options) (*corev1.ConfigMap, string, error) {
 	cfg := ConfigOptions(opt)
-	b, err := config.Build(cfg)
+	c, rc, err := config.Build(cfg)
 	if err != nil {
 		return nil, "", err
 	}
 
 	s := sha1.New()
-	_, err = s.Write(b)
+	_, err = s.Write(c)
 	if err != nil {
 		return nil, "", err
 	}
-	sha1 := fmt.Sprintf("%x", s.Sum(nil))
+	sha1C := fmt.Sprintf("%x", s.Sum(nil))
 
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
@@ -35,9 +35,10 @@ func LokiConfigMap(opt Options) (*corev1.ConfigMap, string, error) {
 			Labels: commonLabels(opt.Name),
 		},
 		BinaryData: map[string][]byte{
-			config.LokiConfigFileName: b,
+			config.LokiConfigFileName:        c,
+			config.LokiRuntimeConfigFileName: rc,
 		},
-	}, sha1, nil
+	}, sha1C, nil
 }
 
 // ConfigOptions converts Options to config.Options

--- a/internal/manifests/config_test.go
+++ b/internal/manifests/config_test.go
@@ -17,10 +17,9 @@ import (
 func TestConfigMap_ReturnsSHA1OfBinaryContents(t *testing.T) {
 	opts := randomConfigOptions()
 
-	_, sha1, err := manifests.LokiConfigMap(opts)
+	_, sha1C, err := manifests.LokiConfigMap(opts)
 	require.NoError(t, err)
-
-	require.NotEmpty(t, sha1)
+	require.NotEmpty(t, sha1C)
 }
 
 func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {

--- a/internal/manifests/distributor.go
+++ b/internal/manifests/distributor.go
@@ -58,6 +58,7 @@ func NewDistributorDeployment(opt Options) *appsv1.Deployment {
 				Args: []string{
 					"-target=distributor",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
+					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{

--- a/internal/manifests/ingester.go
+++ b/internal/manifests/ingester.go
@@ -47,6 +47,7 @@ func NewIngesterStatefulSet(opt Options) *appsv1.StatefulSet {
 				Args: []string{
 					"-target=ingester",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
+					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{

--- a/internal/manifests/internal/config/loki-runtime-config.yaml
+++ b/internal/manifests/internal/config/loki-runtime-config.yaml
@@ -1,0 +1,42 @@
+---
+overrides:
+  {{- range $tenant, $spec := .Stack.Limits.Tenants }}
+  {{ $tenant }}:
+  {{- if $l := $spec.IngestionLimits -}}
+    {{ if $l.IngestionRate }}
+    ingestion_rate_mb: {{ $l.IngestionRate }}
+    {{- end -}}
+    {{ if $l.IngestionBurstSize }}
+    ingestion_burst_size_mb: {{ $l.IngestionBurstSize }}
+    {{- end -}}
+    {{ if $l.MaxLabelNameLength }}
+    max_label_name_length: {{ $l.MaxLabelNameLength }}
+    {{- end -}}
+    {{ if $l.MaxLabelValueLength }}
+    max_label_value_length: {{ $l.MaxLabelValueLength }}
+    {{- end -}}
+    {{ if $l.MaxLabelNamesPerSeries }}
+    max_label_names_per_series: {{ $l.MaxLabelNamesPerSeries }}
+    {{- end -}}
+    {{ if $l.MaxStreamsPerTenant }}
+    max_streams_per_user: {{ $l.MaxStreamsPerTenant }}
+    {{- end -}}
+    {{ if $l.MaxLineSize }}
+    max_line_size: {{ $l.MaxLineSize }}
+    {{- end -}}
+    {{ if $l.MaxGlobalStreamsPerTenant }}
+    max_global_streams_per_user: {{ $l.MaxGlobalStreamsPerTenant }}
+    {{- end -}}
+  {{- end -}}
+  {{- if $l := $spec.QueryLimits -}}
+    {{ if $l.MaxEntriesLimitPerQuery }}
+    max_entries_limit_per_query: {{ $spec.QueryLimits.MaxEntriesLimitPerQuery }}
+    {{- end -}}
+    {{ if $spec.QueryLimits.MaxChunksPerQuery }}
+    max_chunks_per_query: {{ $spec.QueryLimits.MaxChunksPerQuery }}
+    {{- end -}}
+    {{ if $spec.QueryLimits.MaxQuerySeries }}
+    max_query_series: {{ $spec.QueryLimits.MaxQuerySeries }}
+    {{- end -}}
+  {{- end -}}
+  {{- end -}}

--- a/internal/manifests/querier.go
+++ b/internal/manifests/querier.go
@@ -47,6 +47,7 @@ func NewQuerierStatefulSet(opt Options) *appsv1.StatefulSet {
 				Args: []string{
 					"-target=querier",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
+					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{

--- a/internal/manifests/query-frontend.go
+++ b/internal/manifests/query-frontend.go
@@ -52,6 +52,7 @@ func NewQueryFrontendDeployment(opt Options) *appsv1.Deployment {
 				Args: []string{
 					"-target=query-frontend",
 					fmt.Sprintf("-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiConfigFileName)),
+					fmt.Sprintf("-runtime-config.file=%s", path.Join(config.LokiConfigMountDir, config.LokiRuntimeConfigFileName)),
 				},
 				ReadinessProbe: &corev1.Probe{
 					Handler: corev1.Handler{

--- a/internal/manifests/var.go
+++ b/internal/manifests/var.go
@@ -15,9 +15,9 @@ const (
 	DefaultContainerImage = "docker.io/grafana/loki:2.2.1"
 )
 
-func commonAnnotations(sha string) map[string]string {
+func commonAnnotations(h string) map[string]string {
 	return map[string]string{
-		"loki.openshift.io/config-hash": sha,
+		"loki.openshift.io/config-hash": h,
 	}
 }
 


### PR DESCRIPTION
This PR adds reconciliation support for a [runtime-config](https://grafana.com/docs/loki/latest/configuration/#runtime-configuration-file) for all Loki components. The `runtime-config` represents a mean to provide tenant based ingestion/query limits. In detail the implementation adds supports:
- Parse and render the following `LokiStackSpec` section into a separate `runtime-config.yaml`.
- Conditional rendering of limits per tenant. Renders only non-empty values.
- Persist the runtime config file into the `LokiConfigMap` as separate binary blob. 
- All components load this file via the argument `-runtime-config.file`.
- ~A `SHA1` hash is calculated based on the runtime config contents and passed down to components. Any changes of this SHA1 triggers a restart of all components.~

LokiStackSpec:
```yaml
apiVersion: loki.openshift.io/v1beta1
kind: LokiStack
spec:
  ...
  limits:
    tenants:
      tenantA:
        ingestion:
          ingestionRate: 100
          ingestionBurstSize: 200
          maxLabelNameLength: 256
          maxLabelValueLength: 1024
          maxLabelNamesPerSeries: 100
          maxStreamsPerTenant: 1000
          maxGlobalStreamsPerTenant: 2000
        queries:
          maxEntriesLimitPerQuery: 100
          maxChunksPerQuery: 1000
          maxQuerySeries: 2000
      tenantB:
        ingestion:
          ingestionRate: 100
          ingestionBurstSize: 200
          maxLabelNameLength: 256
          maxLabelValueLength: 1024
          maxLabelNamesPerSeries: 100
          maxStreamsPerTenant: 1000
          maxGlobalStreamsPerTenant: 2000
          maxLineSize: 512
```

Runtime config file:
```yaml
overrides:
  tenantA:
    ingestion_rate_mb: 100
    ingestion_burst_size_mb: 200
    max_label_name_length: 256
    max_label_value_length: 1024
    max_label_names_per_series: 100
    max_streams_per_user: 1000
    max_global_streams_per_user: 2000
    max_entries_limit_per_query: 100
    max_chunks_per_query: 1000
    max_query_series: 2000
  tenantB:
    ingestion_rate_mb: 100
    ingestion_burst_size_mb: 200
    max_label_name_length: 256
    max_label_value_length: 1024
    max_label_names_per_series: 100
    max_streams_per_user: 1000
    max_line_size: 512
    max_global_streams_per_user: 2000

```
