### PR TITLE
[SPIKE] Add support for smart restarts

### DIFF
--- a/internal/manifests/build.go
+++ b/internal/manifests/build.go
@@ -18,11 +18,11 @@ func BuildAll(opt Options) ([]client.Object, error) {
 		return nil, err
 	}
 
-	cm, sha1C, err := LokiConfigMap(opt)
+	cm, cres, err := LokiConfigMap(opt)
 	if err != nil {
 		return nil, err
 	}
-	opt.ConfigSHA1 = sha1C
+	opt.Config.CompareResult = cres
 
 	res = append(res, cm)
 	res = append(res, BuildDistributor(opt)...)

--- a/internal/manifests/compactor.go
+++ b/internal/manifests/compactor.go
@@ -34,7 +34,7 @@ func NewCompactorStatefulSet(opt Options) *appsv1.StatefulSet {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: lokiConfigMapName(opt.Name),
+							Name: LokiConfigMapName(opt.Name),
 						},
 					},
 				},
@@ -105,7 +105,7 @@ func NewCompactorStatefulSet(opt Options) *appsv1.StatefulSet {
 	}
 
 	l := ComponentLabels("compactor", opt.Name)
-	a := commonAnnotations(opt.ConfigSHA1)
+	a := commonAnnotations(opt, config.CompareCompactorKey)
 
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/manifests/compactor_test.go
+++ b/internal/manifests/compactor_test.go
@@ -5,6 +5,7 @@ import (
 
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
 	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,9 +38,13 @@ func TestNewCompactorStatefulSet_SelectorMatchesLabels(t *testing.T) {
 
 func TestNewCompactorStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 	ss := manifests.NewCompactorStatefulSet(manifests.Options{
-		Name:       "abcd",
-		Namespace:  "efgh",
-		ConfigSHA1: "deadbeef",
+		Name:      "abcd",
+		Namespace: "efgh",
+		Config: manifests.Config{
+			CompareResult: config.CompareResult{
+				config.CompareCompactorKey: "deadbeef",
+			},
+		},
 		Stack: lokiv1beta1.LokiStackSpec{
 			StorageClassName: "standard",
 			Template: &lokiv1beta1.LokiTemplateSpec{

--- a/internal/manifests/config_test.go
+++ b/internal/manifests/config_test.go
@@ -17,9 +17,9 @@ import (
 func TestConfigMap_ReturnsSHA1OfBinaryContents(t *testing.T) {
 	opts := randomConfigOptions()
 
-	_, sha1C, err := manifests.LokiConfigMap(opts)
+	_, res, err := manifests.LokiConfigMap(opts)
 	require.NoError(t, err)
-	require.NotEmpty(t, sha1C)
+	require.NotEmpty(t, res)
 }
 
 func TestConfigOptions_UserOptionsTakePrecedence(t *testing.T) {

--- a/internal/manifests/distributor.go
+++ b/internal/manifests/distributor.go
@@ -38,7 +38,7 @@ func NewDistributorDeployment(opt Options) *appsv1.Deployment {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: lokiConfigMapName(opt.Name),
+							Name: LokiConfigMapName(opt.Name),
 						},
 					},
 				},
@@ -119,7 +119,7 @@ func NewDistributorDeployment(opt Options) *appsv1.Deployment {
 	}
 
 	l := ComponentLabels("distributor", opt.Name)
-	a := commonAnnotations(opt.ConfigSHA1)
+	a := commonAnnotations(opt, config.CompareDistributorKey)
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/manifests/distributor_test.go
+++ b/internal/manifests/distributor_test.go
@@ -5,6 +5,7 @@ import (
 
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
 	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,9 +31,13 @@ func TestNewDistributorDeployment_SelectorMatchesLabels(t *testing.T) {
 
 func TestNewDistributorDeployme_HasTemplateConfigHashAnnotation(t *testing.T) {
 	ss := manifests.NewDistributorDeployment(manifests.Options{
-		Name:       "abcd",
-		Namespace:  "efgh",
-		ConfigSHA1: "deadbeef",
+		Name:      "abcd",
+		Namespace: "efgh",
+		Config: manifests.Config{
+			CompareResult: config.CompareResult{
+				config.CompareDistributorKey: "deadbeef",
+			},
+		},
 		Stack: lokiv1beta1.LokiStackSpec{
 			Template: &lokiv1beta1.LokiTemplateSpec{
 				Distributor: &lokiv1beta1.LokiComponentSpec{

--- a/internal/manifests/ingester.go
+++ b/internal/manifests/ingester.go
@@ -33,7 +33,7 @@ func NewIngesterStatefulSet(opt Options) *appsv1.StatefulSet {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: lokiConfigMapName(opt.Name),
+							Name: LokiConfigMapName(opt.Name),
 						},
 					},
 				},
@@ -108,7 +108,7 @@ func NewIngesterStatefulSet(opt Options) *appsv1.StatefulSet {
 	}
 
 	l := ComponentLabels("ingester", opt.Name)
-	a := commonAnnotations(opt.ConfigSHA1)
+	a := commonAnnotations(opt, config.CompareIngesterKey)
 
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/manifests/ingester_test.go
+++ b/internal/manifests/ingester_test.go
@@ -5,14 +5,19 @@ import (
 
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
 	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewIngesterStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 	ss := manifests.NewIngesterStatefulSet(manifests.Options{
-		Name:       "abcd",
-		Namespace:  "efgh",
-		ConfigSHA1: "deadbeef",
+		Name:      "abcd",
+		Namespace: "efgh",
+		Config: manifests.Config{
+			CompareResult: config.CompareResult{
+				config.CompareIngesterKey: "deadbeef",
+			},
+		},
 		Stack: lokiv1beta1.LokiStackSpec{
 			StorageClassName: "standard",
 			Template: &lokiv1beta1.LokiTemplateSpec{

--- a/internal/manifests/internal/config/compare.go
+++ b/internal/manifests/internal/config/compare.go
@@ -1,0 +1,100 @@
+package config
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
+)
+
+// CompareResult represents the loki config comparison result type.
+// It defines a mapping from component names to config hashes.
+type CompareResult map[string]string
+
+const (
+	// CompareCompactorKey is the key to access the compactor component hash
+	// from a loki configuration comparison result.
+	CompareCompactorKey string = "compactor"
+	// CompareDistributorKey is the key to access the distributor component hash
+	// from a loki configuration comparison result.
+	CompareDistributorKey string = "distributor"
+	// CompareIngesterKey is the key to access the ingester component hash
+	// from a loki configuration comparison result.
+	CompareIngesterKey string = "ingester"
+	// CompareQuerierKey is the key to access the querier component hash
+	// from a loki configuration comparison result.
+	CompareQuerierKey string = "querier"
+	// CompareQueryFrontendKey is the key to access the query-frontend component hash
+	// from a loki configuration comparison result.
+	CompareQueryFrontendKey string = "query-frontend"
+)
+
+var configToCompopnentMap = map[string][]string{
+	"LimitsConfig":  {CompareDistributorKey, CompareIngesterKey, CompareQuerierKey, CompareQueryFrontendKey},
+	"Ingester":      {CompareIngesterKey},
+	"StorageConfig": {CompareCompactorKey, CompareDistributorKey, CompareIngesterKey, CompareQuerierKey, CompareQueryFrontendKey},
+}
+
+// Compare loads and compares two loki configuration byte slices and returns
+// a mapping of affected components to the corresponding config SHA1 hash.
+// A component is getting a new hash only if the diff between the byte slices
+// affects the component itself. Currently the compare result supports changes:
+// - Limits config: Affect all component except compactor.
+// - Ingester config: Affects only ingester component.
+// - Storage config: Affects all components.
+func Compare(old, new []byte) (CompareResult, error) {
+	// Unmarshal old and new config
+	// contents into Loki objects
+	var o, n Loki
+	err := yaml.Unmarshal(old, &o)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(new, &n)
+	if err != nil {
+		return nil, err
+	}
+
+	// Hash old and new config contents
+	ohash, err := Sha1sum(old)
+	if err != nil {
+		return nil, err
+	}
+	nhash, err := Sha1sum(new)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return all components with old hash
+	// if config contents are equal.
+	var r PathReporter
+	ok := cmp.Equal(o, n, cmp.Reporter(&r))
+	if ok {
+		return all(ohash), nil
+	}
+
+	// Add new hash to affected components
+	res := CompareResult{}
+	for _, rr := range r.Roots() {
+		for _, c := range configToCompopnentMap[rr] {
+			res[c] = nhash
+		}
+	}
+
+	// Add old hash to non-affected components
+	for k, v := range all(ohash) {
+		_, ok := res[k]
+		if !ok {
+			res[k] = v
+		}
+	}
+	return res, nil
+}
+
+func all(h string) CompareResult {
+	return CompareResult{
+		CompareCompactorKey:     h,
+		CompareDistributorKey:   h,
+		CompareIngesterKey:      h,
+		CompareQuerierKey:       h,
+		CompareQueryFrontendKey: h,
+	}
+}

--- a/internal/manifests/internal/config/compare_test.go
+++ b/internal/manifests/internal/config/compare_test.go
@@ -1,0 +1,96 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompare_WhenLimitsConfigNotEqual_ReturnAllWithCompactor(t *testing.T) {
+	var (
+		a = []byte(`
+limits_config:
+  ingestion_rate_mb: 100
+`)
+		b = []byte(`
+limits_config:
+  ingestion_rate_mb: 200
+`)
+		ah, _ = config.Sha1sum(a)
+		bh, _ = config.Sha1sum(b)
+	)
+
+	res, err := config.Compare(a, b)
+	require.NoError(t, err)
+
+	expected := config.CompareResult{
+		config.CompareCompactorKey: ah,
+		// Rest is new hash
+		config.CompareDistributorKey:   bh,
+		config.CompareIngesterKey:      bh,
+		config.CompareQuerierKey:       bh,
+		config.CompareQueryFrontendKey: bh,
+	}
+	require.Exactly(t, expected, res)
+}
+
+func TestCompare_WhenIngesterConfigNotEqual_ReturnOnlyIngester(t *testing.T) {
+	var (
+		a = []byte(`
+ingester:
+  lifecycler:
+    ring:
+      replication_factor: 2
+`)
+		b = []byte(`
+ingester:
+  lifecycler:
+    ring:
+     replication_factor: 1
+`)
+		ah, _ = config.Sha1sum(a)
+		bh, _ = config.Sha1sum(b)
+	)
+
+	res, err := config.Compare(a, b)
+	require.NoError(t, err)
+
+	expected := config.CompareResult{
+		config.CompareIngesterKey: bh,
+		// Rest is old hash
+		config.CompareCompactorKey:     ah,
+		config.CompareDistributorKey:   ah,
+		config.CompareQuerierKey:       ah,
+		config.CompareQueryFrontendKey: ah,
+	}
+	require.Exactly(t, expected, res)
+}
+
+func TestCompare_WhenStorageConfigNotEqual_ReturnAll(t *testing.T) {
+	var (
+		a = []byte(`
+storage_config:
+  aws:
+    region: us-nowhere-42
+`)
+		b = []byte(`
+storage_config:
+  aws:
+    region: us-somewhere-42
+`)
+		bh, _ = config.Sha1sum(b)
+	)
+
+	res, err := config.Compare(a, b)
+	require.NoError(t, err)
+
+	expected := config.CompareResult{
+		config.CompareCompactorKey:     bh,
+		config.CompareDistributorKey:   bh,
+		config.CompareIngesterKey:      bh,
+		config.CompareQuerierKey:       bh,
+		config.CompareQueryFrontendKey: bh,
+	}
+	require.Exactly(t, expected, res)
+}

--- a/internal/manifests/internal/config/diff.go
+++ b/internal/manifests/internal/config/diff.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// PathReporter is a simple custom reporter that only records differences
+// detected during comparison.
+type PathReporter struct {
+	path  cmp.Path
+	diffs []string
+}
+
+// PushStep appends a path to the reporter.
+func (r *PathReporter) PushStep(ps cmp.PathStep) {
+	r.path = append(r.path, ps)
+}
+
+// Report appends only changed paths to the reporter.
+func (r *PathReporter) Report(rs cmp.Result) {
+	if !rs.Equal() {
+		r.diffs = append(r.diffs, r.path.String())
+	}
+}
+
+// PopStep drops a path from the reporter.
+func (r *PathReporter) PopStep() {
+	r.path = r.path[:len(r.path)-1]
+}
+
+// String returns a string representation of all diffs,
+// each one in a single new line.
+func (r *PathReporter) String() string {
+	return strings.Join(r.diffs, "\n")
+}
+
+// Roots returns a slice of all affected path root elements.
+func (r *PathReporter) Roots() []string {
+	var rr []string
+	for _, d := range r.diffs {
+		c := strings.Split(d, ".")
+		rr = append(rr, c[0])
+	}
+	return rr
+}

--- a/internal/manifests/internal/config/diff_test.go
+++ b/internal/manifests/internal/config/diff_test.go
@@ -1,0 +1,84 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathExporter_WhenEqual_ReportNothing(t *testing.T) {
+	var (
+		r    config.PathReporter
+		a, b config.Loki
+	)
+	ok := cmp.Equal(a, b, cmp.Reporter(&r))
+	require.True(t, ok)
+	require.Empty(t, r.String())
+}
+
+func TestPathExporter_WhenNotEqual_ReportDiffPathOnly(t *testing.T) {
+	var (
+		r config.PathReporter
+		a = config.Loki{
+			Ingester: config.Ingester{
+				Lifecycler: config.Lifecycler{
+					Ring: config.Ring{
+						ReplicationFactor: 1,
+					},
+				},
+			},
+		}
+		b = config.Loki{
+			Ingester: config.Ingester{
+				Lifecycler: config.Lifecycler{
+					Ring: config.Ring{
+						ReplicationFactor: 2,
+					},
+				},
+			},
+		}
+	)
+	ok := cmp.Equal(a, b, cmp.Reporter(&r))
+	require.False(t, ok)
+	require.Equal(t, "Ingester.Lifecycler.Ring.ReplicationFactor", r.String())
+}
+
+func TestPathExporter_WhenNotEqual_ReturnRootsOnly(t *testing.T) {
+	var (
+		r config.PathReporter
+		a = config.Loki{
+			Ingester: config.Ingester{
+				Lifecycler: config.Lifecycler{
+					Ring: config.Ring{
+						ReplicationFactor: 1,
+					},
+				},
+			},
+			StorageConfig: config.StorageConfig{
+				AWS: config.AWS{
+					Region: "us-nowhere",
+				},
+			},
+		}
+		b = config.Loki{
+			Ingester: config.Ingester{
+				Lifecycler: config.Lifecycler{
+					Ring: config.Ring{
+						ReplicationFactor: 2,
+					},
+				},
+			},
+			StorageConfig: config.StorageConfig{
+				AWS: config.AWS{
+					Region: "us-somewhere",
+				},
+			},
+		}
+	)
+	ok := cmp.Equal(a, b, cmp.Reporter(&r))
+	require.False(t, ok)
+	expected := []string{"Ingester", "StorageConfig"}
+	require.ElementsMatch(t, expected, r.Roots())
+}

--- a/internal/manifests/internal/config/hash.go
+++ b/internal/manifests/internal/config/hash.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"crypto/sha1"
+	"fmt"
+)
+
+// Sha1sum returns the sha1 checksum for a byte slice
+// or an error if the contents cannot be written into
+// the internal buffer.
+func Sha1sum(c []byte) (string, error) {
+	s := sha1.New()
+	_, err := s.Write(c)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", s.Sum(nil)), nil
+}

--- a/internal/manifests/internal/config/types.go
+++ b/internal/manifests/internal/config/types.go
@@ -1,0 +1,51 @@
+package config
+
+// Loki reprsents the loki configuration file.
+type Loki struct {
+	Ingester      Ingester      `yaml:"ingester"`
+	LimitsConfig  LimitsConfig  `yaml:"limits_config"`
+	StorageConfig StorageConfig `yaml:"storage_config"`
+}
+
+// Ingester represents the ingester configuration section.
+type Ingester struct {
+	Lifecycler Lifecycler `yaml:"lifecycler"`
+}
+
+// Lifecycler represents the ingester lifecycler configuration section.n
+type Lifecycler struct {
+	Ring Ring `yaml:"ring"`
+}
+
+// Ring represents the ingester ring configuration section.
+type Ring struct {
+	ReplicationFactor int32 `yaml:"replication_factor"`
+}
+
+// LimitsConfig represents the limits_config section.
+type LimitsConfig struct {
+	IngestionRate           int32 `yaml:"ingestion_rate_mb"`
+	IngestionBurstSize      int32 `yaml:"ingestion_burst_size_mb"`
+	MaxLabelNameLength      int32 `yaml:"max_label_name_length"`
+	MaxLabelValueLength     int32 `yaml:"max_label_value_length"`
+	MaxLabelNamesPerSeries  int32 `yaml:"max_label_names_per_series"`
+	MaxStreamsPerUser       int32 `yaml:"max_streams_per_user"`
+	MaxLineSize             int32 `yaml:"max_line_size"`
+	MaxGlobalStreamsPerUser int32 `yaml:"max_global_streams_per_user"`
+	MaxEntriesLimitPerQuery int32 `yaml:"max_entries_limit_per_query"`
+	MaxQuerySeries          int32 `yaml:"max_query_series"`
+}
+
+// StorageConfig represents the storage_config section.
+type StorageConfig struct {
+	AWS AWS `yaml:"aws"`
+}
+
+// AWS represents the aws storage_config section.
+type AWS struct {
+	S3              string `yaml:"s3"`
+	BucketNames     string `yaml:"bucketnames"`
+	Region          string `yaml:"region"`
+	AccessKeyID     string `yaml:"access_key_id"`
+	SecretAccessKey string `yaml:"secret_access_key"`
+}

--- a/internal/manifests/options.go
+++ b/internal/manifests/options.go
@@ -3,20 +3,29 @@ package manifests
 import (
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
 	"github.com/ViaQ/loki-operator/internal/manifests/internal"
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 )
 
 // Options is a set of configuration values to use when building manifests such as resource sizes, etc.
 // Most of this should be provided - either directly or indirectly - by the user.
 type Options struct {
-	Name       string
-	Namespace  string
-	Image      string
-	ConfigSHA1 string
+	Name      string
+	Namespace string
+	Image     string
+
+	Config Config
 
 	Stack                lokiv1beta1.LokiStackSpec
 	ResourceRequirements internal.ResourceRequirements
 
 	ObjectStorage ObjectStorage
+}
+
+// Config for config map contents.
+type Config struct {
+	Config        []byte
+	RuntimeConfig []byte
+	CompareResult config.CompareResult
 }
 
 // ObjectStorage for storage config.

--- a/internal/manifests/querier.go
+++ b/internal/manifests/querier.go
@@ -33,7 +33,7 @@ func NewQuerierStatefulSet(opt Options) *appsv1.StatefulSet {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: lokiConfigMapName(opt.Name),
+							Name: LokiConfigMapName(opt.Name),
 						},
 					},
 				},
@@ -108,7 +108,7 @@ func NewQuerierStatefulSet(opt Options) *appsv1.StatefulSet {
 	}
 
 	l := ComponentLabels("querier", opt.Name)
-	a := commonAnnotations(opt.ConfigSHA1)
+	a := commonAnnotations(opt, config.CompareQuerierKey)
 
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/manifests/querier_test.go
+++ b/internal/manifests/querier_test.go
@@ -5,14 +5,19 @@ import (
 
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
 	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewQuerierStatefulSet_HasTemplateConfigHashAnnotation(t *testing.T) {
 	ss := manifests.NewQuerierStatefulSet(manifests.Options{
-		Name:       "abcd",
-		Namespace:  "efgh",
-		ConfigSHA1: "deadbeef",
+		Name:      "abcd",
+		Namespace: "efgh",
+		Config: manifests.Config{
+			CompareResult: config.CompareResult{
+				config.CompareQuerierKey: "deadbeef",
+			},
+		},
 		Stack: lokiv1beta1.LokiStackSpec{
 			StorageClassName: "standard",
 			Template: &lokiv1beta1.LokiTemplateSpec{

--- a/internal/manifests/query-frontend.go
+++ b/internal/manifests/query-frontend.go
@@ -32,7 +32,7 @@ func NewQueryFrontendDeployment(opt Options) *appsv1.Deployment {
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
 						LocalObjectReference: corev1.LocalObjectReference{
-							Name: lokiConfigMapName(opt.Name),
+							Name: LokiConfigMapName(opt.Name),
 						},
 					},
 				},
@@ -109,7 +109,7 @@ func NewQueryFrontendDeployment(opt Options) *appsv1.Deployment {
 	}
 
 	l := ComponentLabels("query-frontend", opt.Name)
-	a := commonAnnotations(opt.ConfigSHA1)
+	a := commonAnnotations(opt, config.CompareQueryFrontendKey)
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/internal/manifests/query-frontend_test.go
+++ b/internal/manifests/query-frontend_test.go
@@ -5,6 +5,7 @@ import (
 
 	lokiv1beta1 "github.com/ViaQ/loki-operator/api/v1beta1"
 	"github.com/ViaQ/loki-operator/internal/manifests"
+	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
@@ -29,9 +30,13 @@ func TestNewQueryFrontendDeployment_SelectorMatchesLabels(t *testing.T) {
 
 func TestNewQueryFrontendDeployment_HasTemplateConfigHashAnnotation(t *testing.T) {
 	ss := manifests.NewQueryFrontendDeployment(manifests.Options{
-		Name:       "abcd",
-		Namespace:  "efgh",
-		ConfigSHA1: "deadbeef",
+		Name:      "abcd",
+		Namespace: "efgh",
+		Config: manifests.Config{
+			CompareResult: config.CompareResult{
+				config.CompareQueryFrontendKey: "deadbeef",
+			},
+		},
 		Stack: lokiv1beta1.LokiStackSpec{
 			Template: &lokiv1beta1.LokiTemplateSpec{
 				QueryFrontend: &lokiv1beta1.LokiComponentSpec{

--- a/internal/manifests/var.go
+++ b/internal/manifests/var.go
@@ -15,9 +15,9 @@ const (
 	DefaultContainerImage = "docker.io/grafana/loki:2.2.1"
 )
 
-func commonAnnotations(h string) map[string]string {
+func commonAnnotations(opt Options, componentName string) map[string]string {
 	return map[string]string{
-		"loki.openshift.io/config-hash": h,
+		"loki.openshift.io/config-hash": opt.Config.CompareResult[componentName],
 	}
 }
 


### PR DESCRIPTION
### Problem statement
The `LokiStack` CR allows only an opinionated list of knobs to configure the operator-managed Loki instances. In total there are three distinct configuration groups namely `ingester.lifecycler.ring.replication_factor`, `limits_config`, `storage_config`. The first group affects only `ingesters`, the second all except `compactor` and the third affects all components. Hence the problem at hand is to define a mechanism in the loki operator to restart only affected components. In turn this enables almost zero-disruption for non-affected components.

### Proposed implementation
This spike considers two configuration sources to keep the operator stateless as is. The one source is the contents persistent in the Loki ConfigMap and represents the current state of the union. The other source is the generated **but** not persisted ConfigMap from the `LokiStackSpec` and represents the desired state. The high level overview of the implementation is to compare both configuration states and provide a mapping of hashes for all component, where affected components have an updated hash. These hashes are applied to pod template annotations which the k8s scheduler considers for restarting the pods.

In summary the implementation provides the following steps:
1. Unmarshal both config contents in partial `Loki` config objects.
2. Compare them with [google-cmp](https://pkg.go.dev/github.com/google/go-cmp/cmp) using a custom reporter to register the roots of changed paths only.
3. Map the roots to a static list of affected components.
4. Return only a hash of the new config for affected components.
5. Return the old hash for non-affected components.

### Alternative approaches
The following alternatives have been considered but withdrawn:
1. Import grafana/loki as go-module to omit implementing custom loki config objects. **Withdrawn:** Loki does not follow go module conventions and in turn is not a meant to be vendored.
2. Looking for copy/paste-able sources in grafana/loki to unmarshal YAML into them. **Withdrawn:** As per Loki config objects are scattered across the upstream source code. Identification of all of them is error-prone and provides diminishing returns for supporting only an opinionated subset.

### Open questions
Although the exploration here aims to enable partial restarts of affected components, further questions remain if the proposed work and current implementation is the right mix for the operator:
1. How to maintain a static mapping of config keys to components across loki versions? Is this only a matter of another level of indirection?
2. What is the impact of deprecated & removed keys from the loki configuration? How does this impact the upgrade path in the operator?
3. Are there any hidden gems in the Loki configuration which demand to restart the whole cluster but not identifiable from the present configuration grouping?

cc @cyriltovena @slim-bean @owen-d
