### PR TITLE
Fix query path configuration

### DIFF
--- a/internal/manifests/config.go
+++ b/internal/manifests/config.go
@@ -48,15 +48,15 @@ func ConfigOptions(opt Options) config.Options {
 		Namespace: opt.Namespace,
 		Name:      opt.Name,
 		FrontendWorker: config.Address{
-			FQDN: fqdn(NewQueryFrontendHTTPService(opt.Name).GetName(), opt.Namespace),
-			Port: httpPort,
+			FQDN: fqdn(NewQueryFrontendGRPCService(opt.Name).GetName(), opt.Namespace),
+			Port: grpcPort,
 		},
 		GossipRing: config.Address{
 			FQDN: fqdn(BuildLokiGossipRingService(opt.Name).GetName(), opt.Namespace),
 			Port: gossipPort,
 		},
 		Querier: config.Address{
-			FQDN: serviceNameQuerierHTTP(opt.Name),
+			FQDN: fqdn(NewQuerierHTTPService(opt.Name).GetName(), opt.Namespace),
 			Port: httpPort,
 		},
 		StorageDirectory: strings.TrimRight(dataDirectory, "/"),

--- a/internal/manifests/internal/config/loki-config.yaml
+++ b/internal/manifests/internal/config/loki-config.yaml
@@ -12,8 +12,7 @@ distributor:
     kvstore:
       store: memberlist
 frontend:
-  downstream_url: {{ .Querier.FQDN }}:{{ .Querier.Port }}
-  tail_proxy_url: {{ .Querier.FQDN }}:{{ .Querier.Port }}
+  tail_proxy_url: http://{{ .Querier.FQDN }}:{{ .Querier.Port }}
   compress_responses: true
   max_outstanding_per_tenant: 256
   log_queries_longer_than: 5s


### PR DESCRIPTION
This PR provides a small fix for the configuration options that affect successful query/tail of logs from query frontend to queriers. In detail the `downstream_url` is removed as per serving traffic from a local loki cluster via GRPC and not from a remote one. Furthermore the `tail_proxy_url` is adapted to use the HTTP service as expected.