### PR TITLE
Fix broker to read a CR and generate manifests

### DIFF
--- a/cmd/loki-broker/main.go
+++ b/cmd/loki-broker/main.go
@@ -9,22 +9,76 @@ import (
 	"strings"
 
 	"github.com/ViaQ/logerr/log"
+	"github.com/ViaQ/loki-operator/api/v1beta1"
 	"github.com/ViaQ/loki-operator/internal/manifests"
 	"sigs.k8s.io/yaml"
 )
 
 // Define the manifest options here as structured objects
 type config struct {
-	Name       string
-	Namespace  string
-	Replicas   int
+	Name      string
+	Namespace string
+	Image     string
+
+	featureFlags  manifests.FeatureFlags
+	objectStorage manifests.ObjectStorage
+
+	crFilepath string
 	writeToDir string
 }
 
 func (c *config) registerFlags(f *flag.FlagSet) {
-	f.StringVar(&c.Name, "name", "", "the name of the stack")
+	// LokiStack metadata options
+	f.StringVar(&c.Name, "name", "", "The name of the stack")
 	f.StringVar(&c.Namespace, "namespace", "", "Namespace to deploy to")
-	f.StringVar(&c.writeToDir, "output.write-dir", "", "write each file to the specified directory")
+	f.StringVar(&c.Image, "image", manifests.DefaultContainerImage, "The Loki image pull spec loation.")
+	// Feature flags
+	c.featureFlags = manifests.FeatureFlags{}
+	f.BoolVar(&c.featureFlags.EnableCertificateSigningService, "with-cert-signing-service", false, "Enable usage of cert-signing service for scraping prometheus metrics via TLS.")
+	f.BoolVar(&c.featureFlags.EnableServiceMonitors, "with-service-monitors", false, "Enable service monitors for all LokiStack components.")
+	f.BoolVar(&c.featureFlags.EnableTLSServiceMonitorConfig, "with-tls-service-monitors", false, "Enable TLS endpoint for service monitors.")
+	// Object storage options
+	c.objectStorage = manifests.ObjectStorage{}
+	f.StringVar(&c.objectStorage.Endpoint, "object-storage.endpoint", "", "The S3 endpoint location.")
+	f.StringVar(&c.objectStorage.Buckets, "object-storage.buckets", "", "A comma-separated list of S3 buckets.")
+	f.StringVar(&c.objectStorage.Region, "object-storage.region", "", "An S3 region.")
+	f.StringVar(&c.objectStorage.AccessKeyID, "object-storage.access-key-id", "", "The access key id for S3.")
+	f.StringVar(&c.objectStorage.AccessKeySecret, "object-storage.access-key-secret", "", "The access key secret for S3.")
+	// Input and output file/dir options
+	f.StringVar(&c.crFilepath, "custom-resource.path", "", "Path to a custom resource YAML file.")
+	f.StringVar(&c.writeToDir, "output.write-dir", "", "write each file to the specified directory.")
+}
+
+func (c *config) validateFlags() {
+	if cfg.crFilepath == "" {
+		log.Info("-custom.resource.path flag is required")
+		os.Exit(1)
+	}
+	if cfg.Name == "" {
+		log.Info("-name flag is required")
+		os.Exit(1)
+	}
+	if cfg.Namespace == "" {
+		log.Info("-namespace flag is required")
+		os.Exit(1)
+	}
+	// Validate manifests.objectStorage
+	if cfg.objectStorage.Endpoint == "" {
+		log.Info("-object.storage.endpoint flag is required")
+		os.Exit(1)
+	}
+	if cfg.objectStorage.Buckets == "" {
+		log.Info("-object.storage.buckets flag is required")
+		os.Exit(1)
+	}
+	if cfg.objectStorage.AccessKeyID == "" {
+		log.Info("-object.storage.access.key.id flag is required")
+		os.Exit(1)
+	}
+	if cfg.objectStorage.AccessKeySecret == "" {
+		log.Info("-object.storage.access.key.secret flag is required")
+		os.Exit(1)
+	}
 }
 
 var cfg *config
@@ -41,15 +95,33 @@ func main() {
 		log.Error(err, "failed to parse flags")
 	}
 
-	if cfg.Name == "" {
-		log.Info("-name flag is required")
+	cfg.validateFlags()
+
+	b, err := ioutil.ReadFile(cfg.crFilepath)
+	if err != nil {
+		log.Info("failed to read custom resource file", "path", cfg.crFilepath)
+		os.Exit(1)
+	}
+
+	ls := &v1beta1.LokiStack{}
+	if err = yaml.Unmarshal(b, ls); err != nil {
+		log.Error(err, "failed to unmarshal LokiStack CR", "path", cfg.crFilepath)
 		os.Exit(1)
 	}
 
 	// Convert config to manifest.Options
 	opts := manifests.Options{
-		Name:      cfg.Name,
-		Namespace: cfg.Namespace,
+		Name:          cfg.Name,
+		Namespace:     cfg.Namespace,
+		Image:         cfg.Image,
+		Stack:         ls.Spec,
+		Flags:         cfg.featureFlags,
+		ObjectStorage: cfg.objectStorage,
+	}
+
+	if optErr := manifests.ApplyDefaultSettings(&opts); optErr != nil {
+		log.Error(optErr, "failed to conform options to build settings")
+		os.Exit(1)
 	}
 
 	objects, err := manifests.BuildAll(opts)


### PR DESCRIPTION
This PR completes the broker binary to generate Loki manifests based on a custom resource file. In addition it provides support to configure a custom object storage endpoint as well as enabling feature flags.

Example usage:
```shell
$ loki-broker \
 -name test-lokistack \
 -namespace test-namespace \
 -object-storage.endpoint=s3://localhost \
 -object-storage.buckets=baba,bobo \
 -object-storage.access-key-id=123 \
 -object-storage.access-key-secret=secrettt \
 -object-storage.region=nirvana \
 -custom-resource.path hack/lokistack_dev.yaml \
 -output.write-dir tmp/loki-broker
```

Input CR:
```yaml
apiVersion: loki.openshift.io/v1beta1
kind: LokiStack
metadata:
  name: lokistack-dev
spec:
  size: 1x.extra-small
  replicationFactor: 1
  storage:
    secret:
      name: test
  storageClassName: standard
```

Generated output:
```shell
$ lt tmp/loki-broker/
tmp/loki-broker
├── configmap-loki-config-test-lokistack.yaml
├── deployment-loki-distributor-test-lokistack.yaml
├── deployment-loki-query-frontend-test-lokistack.yaml
├── service-loki-compactor-grpc-test-lokistack.yaml
├── service-loki-compactor-http-test-lokistack.yaml
├── service-loki-distributor-grpc-test-lokistack.yaml
├── service-loki-distributor-http-test-lokistack.yaml
├── service-loki-gossip-ring-test-lokistack.yaml
├── service-loki-ingester-grpc-test-lokistack.yaml
├── service-loki-ingester-http-test-lokistack.yaml
├── service-loki-querier-grpc-test-lokistack.yaml
├── service-loki-querier-http-test-lokistack.yaml
├── service-loki-query-frontend-grpc-test-lokistack.yaml
├── service-loki-query-frontend-http-test-lokistack.yaml
├── statefulset-loki-compactor-test-lokistack.yaml
├── statefulset-loki-ingester-test-lokistack.yaml
└── statefulset-loki-querier-test-lokistack.yaml
````