### PR TITLE
add reconcile for dependent objects ( such as the storage secret )

### DIFF
--- a/internal/handlers/internal/secrets/secrets.go
+++ b/internal/handlers/internal/secrets/secrets.go
@@ -1,6 +1,9 @@
 package secrets
 
 import (
+	"crypto/sha1"
+	"fmt"
+
 	"github.com/ViaQ/logerr/kverrors"
 	"github.com/ViaQ/loki-operator/internal/manifests"
 
@@ -8,24 +11,24 @@ import (
 )
 
 // Extract reads a k8s secret into a manifest object storage struct if valid.
-func Extract(s *corev1.Secret) (*manifests.ObjectStorage, error) {
+func Extract(s *corev1.Secret) (*manifests.ObjectStorage, string, error) {
 	// Extract and validate mandatory fields
 	endpoint, ok := s.Data["endpoint"]
 	if !ok {
-		return nil, kverrors.New("missing secret field", "field", "endpoint")
+		return nil, "", kverrors.New("missing secret field", "field", "endpoint")
 	}
 	buckets, ok := s.Data["bucketnames"]
 	if !ok {
-		return nil, kverrors.New("missing secret field", "field", "bucketnames")
+		return nil, "", kverrors.New("missing secret field", "field", "bucketnames")
 	}
 	// TODO buckets are comma-separated list
 	id, ok := s.Data["access_key_id"]
 	if !ok {
-		return nil, kverrors.New("missing secret field", "field", "access_key_id")
+		return nil, "", kverrors.New("missing secret field", "field", "access_key_id")
 	}
 	secret, ok := s.Data["access_key_secret"]
 	if !ok {
-		return nil, kverrors.New("missing secret field", "field", "access_key_secret")
+		return nil, "", kverrors.New("missing secret field", "field", "access_key_secret")
 	}
 
 	// Extract and validate optional fields
@@ -34,11 +37,17 @@ func Extract(s *corev1.Secret) (*manifests.ObjectStorage, error) {
 		region = []byte("")
 	}
 
-	return &manifests.ObjectStorage{
+	s3secret := manifests.ObjectStorage{
 		Endpoint:        string(endpoint),
 		Buckets:         string(buckets),
 		AccessKeyID:     string(id),
 		AccessKeySecret: string(secret),
 		Region:          string(region),
-	}, nil
+	}
+
+	sha := sha1.New()
+	sha.Write([]byte(fmt.Sprintf("%v", s3secret)))
+	sha1Storage := fmt.Sprintf("%x", sha.Sum(nil))
+
+	return &s3secret, sha1Storage, nil
 }

--- a/internal/handlers/internal/secrets/secrets_test.go
+++ b/internal/handlers/internal/secrets/secrets_test.go
@@ -67,7 +67,7 @@ func TestExtract(t *testing.T) {
 		t.Run(tst.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := secrets.Extract(tst.secret)
+			_, _, err := secrets.Extract(tst.secret)
 			if !tst.wantErr {
 				require.NoError(t, err)
 			}

--- a/internal/handlers/lokistack_create_or_update_test.go
+++ b/internal/handlers/lokistack_create_or_update_test.go
@@ -39,6 +39,8 @@ var (
 		EnableTLSServiceMonitorConfig:   false,
 	}
 
+	dependentObjectsMap = map[types.NamespacedName]types.NamespacedName{}
+
 	defaultSecret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "some-stack-secret",
@@ -98,7 +100,7 @@ func TestCreateOrUpdateLokiStack_WhenGetReturnsNotFound_DoesNotError(t *testing.
 		return apierrors.NewNotFound(schema.GroupResource{}, "something wasn't found")
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 	require.NoError(t, err)
 
 	// make sure create was NOT called because the Get failed
@@ -119,7 +121,7 @@ func TestCreateOrUpdateLokiStack_WhenGetReturnsAnErrorOtherThanNotFound_ReturnsT
 		return badRequestErr
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 
 	require.Equal(t, badRequestErr, errors.Unwrap(err))
 
@@ -172,7 +174,7 @@ func TestCreateOrUpdateLokiStack_SetsNamespaceOnAllObjects(t *testing.T) {
 		return nil
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 	require.NoError(t, err)
 
 	// make sure create was called
@@ -246,7 +248,7 @@ func TestCreateOrUpdateLokiStack_SetsOwnerRefOnAllObjects(t *testing.T) {
 		return nil
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 	require.NoError(t, err)
 
 	// make sure create was called
@@ -295,7 +297,7 @@ func TestCreateOrUpdateLokiStack_WhenSetControllerRefInvalid_ContinueWithOtherOb
 		return nil
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 
 	// make sure error is returned to re-trigger reconciliation
 	require.Error(t, err)
@@ -387,7 +389,7 @@ func TestCreateOrUpdateLokiStack_WhenGetReturnsNoError_UpdateObjects(t *testing.
 		return nil
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 	require.NoError(t, err)
 
 	// make sure create not called
@@ -444,7 +446,7 @@ func TestCreateOrUpdateLokiStack_WhenCreateReturnsError_ContinueWithOtherObjects
 		return apierrors.NewTooManyRequestsError("too many create requests")
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 
 	// make sure error is returned to re-trigger reconciliation
 	require.Error(t, err)
@@ -542,7 +544,7 @@ func TestCreateOrUpdateLokiStack_WhenUpdateReturnsError_ContinueWithOtherObjects
 		return apierrors.NewTooManyRequestsError("too many create requests")
 	}
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 
 	// make sure error is returned to re-trigger reconciliation
 	require.Error(t, err)
@@ -589,7 +591,7 @@ func TestCreateOrUpdateLokiStack_WhenMissingSecret_SetDegraded(t *testing.T) {
 
 	k.StatusStub = func() client.StatusWriter { return sw }
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 
 	// make sure error is returned to re-trigger reconciliation
 	require.NoError(t, err)
@@ -644,7 +646,7 @@ func TestCreateOrUpdateLokiStack_WhenInvalidSecret_SetDegraded(t *testing.T) {
 
 	k.StatusStub = func() client.StatusWriter { return sw }
 
-	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags)
+	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, flags, dependentObjectsMap)
 
 	// make sure error is returned to re-trigger reconciliation
 	require.NoError(t, err)

--- a/internal/manifests/compactor.go
+++ b/internal/manifests/compactor.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/ViaQ/logerr/log"
+	"github.com/imdario/mergo"
+
 	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -126,6 +129,9 @@ func NewCompactorStatefulSet(opts Options) *appsv1.StatefulSet {
 
 	l := ComponentLabels(LabelCompactorComponent, opts.Name)
 	a := commonAnnotations(opts.ConfigSHA1)
+	if err := mergo.Merge(a, storageAnnotations(opts.StorageSHA1)); err != nil {
+		log.Error(err, "Failed merging annotations")
+	}
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",

--- a/internal/manifests/ingester.go
+++ b/internal/manifests/ingester.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/ViaQ/logerr/log"
+	"github.com/imdario/mergo"
+
 	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -130,6 +133,9 @@ func NewIngesterStatefulSet(opts Options) *appsv1.StatefulSet {
 
 	l := ComponentLabels(LabelIngesterComponent, opts.Name)
 	a := commonAnnotations(opts.ConfigSHA1)
+	if err := mergo.Merge(a, storageAnnotations(opts.StorageSHA1)); err != nil {
+		log.Error(err, "Failed merging annotations")
+	}
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",

--- a/internal/manifests/options.go
+++ b/internal/manifests/options.go
@@ -8,10 +8,11 @@ import (
 // Options is a set of configuration values to use when building manifests such as resource sizes, etc.
 // Most of this should be provided - either directly or indirectly - by the user.
 type Options struct {
-	Name       string
-	Namespace  string
-	Image      string
-	ConfigSHA1 string
+	Name        string
+	Namespace   string
+	Image       string
+	ConfigSHA1  string
+	StorageSHA1 string
 
 	Flags FeatureFlags
 

--- a/internal/manifests/querier.go
+++ b/internal/manifests/querier.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"path"
 
+	"github.com/ViaQ/logerr/log"
+	"github.com/imdario/mergo"
+
 	"github.com/ViaQ/loki-operator/internal/manifests/internal/config"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -130,7 +133,9 @@ func NewQuerierStatefulSet(opts Options) *appsv1.StatefulSet {
 
 	l := ComponentLabels(LabelQuerierComponent, opts.Name)
 	a := commonAnnotations(opts.ConfigSHA1)
-
+	if err := mergo.Merge(a, storageAnnotations(opts.StorageSHA1)); err != nil {
+		log.Error(err, "Failed merging annotations")
+	}
 	return &appsv1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",

--- a/internal/manifests/var.go
+++ b/internal/manifests/var.go
@@ -49,6 +49,12 @@ func commonAnnotations(h string) map[string]string {
 	}
 }
 
+func storageAnnotations(h string) map[string]string {
+	return map[string]string{
+		"loki.openshift.io/storage-hash": h,
+	}
+}
+
 func commonLabels(stackName string) map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":     "loki",

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"os"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	"github.com/ViaQ/logerr/log"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -96,10 +98,11 @@ func main() {
 	}
 
 	if err = (&controllers.LokiStackReconciler{
-		Client: mgr.GetClient(),
-		Log:    log.WithName("controllers").WithName("LokiStack"),
-		Scheme: mgr.GetScheme(),
-		Flags:  featureFlags,
+		Client:              mgr.GetClient(),
+		Log:                 log.WithName("controllers").WithName("LokiStack"),
+		Scheme:              mgr.GetScheme(),
+		Flags:               featureFlags,
+		DependentObjectsMap: map[types.NamespacedName]types.NamespacedName{},
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller", "controller", "LokiStack")
 		os.Exit(1)


### PR DESCRIPTION
When changing one of the dependent objects, specifically storage secret the operator need to redeploy relevant objects