### PR TITLE
Simple minio docs for developers

### DIFF
--- a/hack/addons.yaml
+++ b/hack/addons.yaml
@@ -10,13 +10,13 @@ metadata:
     app.kubernetes.io/name: logcli
 spec:
   containers:
-  - name: logcli
-    image: docker.io/grafana/logcli:2.2.0-amd64
-    env:
-      - name: LOKI_ADDR
-        value: http://loki-querier-http-lokistack-sample.loki.svc.cluster.local:3100
-    command: [ "/bin/sh", "-c", "--" ]
-    args: [ "while true; do sleep 30; done;" ]
+    - name: logcli
+      image: docker.io/grafana/logcli:2.2.0-amd64
+      env:
+        - name: LOKI_ADDR
+          value: http://loki-querier-http-lokistack-dev.loki.svc.cluster.local:3100
+      command: ["/bin/sh", "-c", "--"]
+      args: ["while true; do sleep 30; done;"]
 
 ---
 apiVersion: apps/v1
@@ -41,7 +41,7 @@ spec:
       containers:
         - args:
             - -config.file=/etc/promtail/promtail.yaml
-            - -client.url=http://loki-distributor-http-lokistack-sample.loki.svc.cluster.local:3100/api/prom/push
+            - -client.url=http://loki-distributor-http-lokistack-dev.loki.svc.cluster.local:3100/api/prom/push
             - -log.level=info
           env:
             - name: HOSTNAME
@@ -418,18 +418,18 @@ metadata:
   labels:
     app.kubernetes.io/name: promtail
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - nodes
-  - nodes/proxy
-  - services
-  - endpoints
-  - pods
-  verbs:
-  - get
-  - watch
-  - list
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - watch
+      - list
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -443,6 +443,6 @@ roleRef:
   kind: ClusterRole
   name: loki-promtail-clusterrole
 subjects:
-- kind: ServiceAccount
-  name: loki-promtail
-  namespace: loki
+  - kind: ServiceAccount
+    name: loki-promtail
+    namespace: loki

--- a/hack/minio-deploy-example-secret.sh
+++ b/hack/minio-deploy-example-secret.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eou pipefail
+
+NAMESPACE=$1
+
+REGION=""
+ENDPOINT=""
+ACCESS_KEY_ID=""
+SECRET_ACCESS_KEY=""
+
+set_credentials_from_aws() {
+  REGION="eu1"
+  ENDPOINT="https://minio.loki.svc.cluster.local:9000"
+  ACCESS_KEY_ID=$(kubectl get secret minio-tenant-1-creds-secret -n loki -o jsonpath={.data.accesskey} |base64 -d)
+  SECRET_ACCESS_KEY=$(kubectl get secret minio-tenant-1-creds-secret -n loki -o jsonpath={.data.secretkey} |base64 -d)
+}
+
+create_secret() {
+  kubectl -n $NAMESPACE delete secret test ||:
+  kubectl -n $NAMESPACE create secret generic test \
+    --from-literal=endpoint=$(echo -n "$ENDPOINT") \
+    --from-literal=region=$(echo -n "$REGION") \
+    --from-literal=bucketnames=$(echo -n "loki") \
+    --from-literal=access_key_id=$(echo -n "$ACCESS_KEY_ID") \
+    --from-literal=access_key_secret=$(echo -n "$SECRET_ACCESS_KEY")
+}
+
+main() {
+  set_credentials_from_aws
+  create_secret
+}
+
+main

--- a/hack/minio.md
+++ b/hack/minio.md
@@ -1,0 +1,92 @@
+# Loki with local s3 bucket
+
+If you want to give this operator a quick test without having to setup a aws account you can use something like Minio.
+This guide is just to test the loki operator, nothing else, don't use this setup in production.
+
+## Setup Minio
+
+Minio have a simple cli tool to make life easier, you can install the cli by following the [docs](https://github.com/minio/operator#1-install-the-minio-operator)
+
+or you can use [krew](https://github.com/kubernetes-sigs/krew), if you have it installed.
+
+```shell
+kubectl krew install minio
+```
+
+### Install operator and tenant
+
+This command will create a two deployments in minio-operator namespace.
+
+```shell
+kubectl minio init
+```
+
+This command will create a tenant with a few basic configs.
+
+I use the loki namespace, since this is where I have installed the operator.
+
+```shell
+kubectl create ns loki
+kubectl minio tenant create minio-tenant-1       \
+  --servers                 1                    \
+  --volumes                 4                    \
+  --capacity                1Gi                 \
+  --storage-class           standard             \
+  --namespace               loki
+```
+
+The minio tenant takes up to 5 minutes to setup so be patient:
+
+```shell
+kubectl get tenants.minio.min.io -w -n loki
+```
+
+In the end you should have something like this:
+
+```shell
+kubectl get pods
+NAME                                      READY   STATUS    RESTARTS   AGE
+minio-tenant-1-console-859c7b6f48-9qsv4   1/1     Running   0          14m
+minio-tenant-1-console-859c7b6f48-zkkq2   1/1     Running   0          14m
+minio-tenant-1-ss-0-0                     1/1     Running   0          15m
+
+kubectl get svc
+NAME                     TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+minio                    ClusterIP   10.96.209.21    <none>        443/TCP    17m
+minio-tenant-1-console   ClusterIP   10.96.192.143   <none>        9443/TCP   15m
+minio-tenant-1-hl        ClusterIP   None            <none>        9000/TCP   17m
+
+# Ignore that it says Waiting for pods to be ready, I think this is due to that i really wants for 4 replicas and not 1
+kubectl get tenants.minio.min.io
+NAME             STATE                          AGE
+minio-tenant-1   Waiting for Pods to be ready   17m
+```
+
+### Create S3 bucket
+
+First lets get the aws access and secret key:
+
+```shell
+# access key
+kubectl get secret minio-tenant-1-creds-secret -o jsonpath={.data.accesskey} |base64 -d
+# secret key
+kubectl get secret minio-tenant-1-creds-secret -o jsonpath={.data.secretkey} |base64 -d
+
+# port-forward to the s3 bucket
+kubectl port-forward service/minio 9000:443
+```
+
+Now you can reach the s3 bucket from your browser on `localhost:9000`, use the access key and secret key to login.
+
+Login to the console and in the bottom right you will find a `+` sign, push it and create a bucket.
+To be able to use the script out of the box, I suggest calling the bucket loki.
+
+## Configure loki operator
+
+Use the config defined in hack, to create the needed secret file use `minio-deploy-example-secret.sh`.
+
+## Connect to loki
+
+You should now be able to use your grafana instance to connect to loki:
+
+http://loki-query-frontend-http-lokistack-dev.loki.svc.cluster.local:3100


### PR DESCRIPTION
Hi, I know this project is in the development phase but I wanted to give it a try but I was way to lazy to create a new AWS account for this, in retrospect this might have been easier...

So I started to write a small guide on how to use minio together with loki, I hope this is something that you might think is useful in the long run.

I also updated hack/addons.yaml to match with the example that you are using in dev.

I'm currently having some issues, most likley due to that I haven't configured the Minio certificate to be used by loki.
In short I will keep on working on this if you think it's useful for you to have.
I know that RedHat uses OCS (ceph) but my poor laptop can't handle that load so I went with minio.

Bellow information is for my future debugging.
A simple test using logcli,

```shell
logcli query '{job="cortex-ops/consul"}'

http://loki-querier-http-lokistack-dev.loki.svc.cluster.local:3100/loki/api/v1/query_range?direction=BACKWARD&end=1629627846296171506&limit=30&query=%7Bjob%3D%22cortex-ops%2Fconsul%22%7D&start=1629624246296171506
Query failed: Error response from server: RequestError: send request failed
caused by: Get "https://minio.loki-operator-system.svc.cluster.local:9000/loki?delimiter=%2F&list-type=2&prefix=index%2Findex_18861%2F": dial tcp 10.96.209.21:9000: i/o timeout
```

In the minio pod I can see the following:

```
kubectl logs -n loki-operator-system minio-tenant-1-ss-0-0 
{"level":"INFO","errKind":"","time":"2021-08-22T08:28:12.3772888Z","message":"Formatting 1st pool, 1 set(s), 4 drives per set."}
{"level":"INFO","errKind":"","time":"2021-08-22T08:28:12.378198856Z","message":"WARNING: Host local has more than 2 drives of set. A host failure will result in data becoming unavailable."}
{"level":"INFO","errKind":"","time":"2021-08-22T08:28:12.431675625Z","message":"IAM initialization complete"}
2021/08/22 08:36:39 http: TLS handshake error from 127.0.0.1:48022: remote error: tls: unknown certificate
```