### PR TITLE
Fix send coverage workflow

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -90,3 +90,4 @@ jobs:
       with:
         path-to-profile: profile.cov
         flag-name: Go-${{ matrix.go }}
+        shallow: true


### PR DESCRIPTION
This PR:
- Fix send coverage workflow which was returning 405 error because of maintenance at coverall.
- `shallow: true` - Shallow coveralls internal server errors
- Ref: https://github.com/shogo82148/actions-goveralls/pull/283

/cc @periklis 