### PR TITLE
Fix upstream calls to Loki using server-side TLS when provided

### DIFF
--- a/internal/manifests/gateway.go
+++ b/internal/manifests/gateway.go
@@ -49,7 +49,7 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 
 	if opts.Stack.Tenants != nil {
 		mode := opts.Stack.Tenants.Mode
-		if err := configureDeploymentForMode(&dpl.Spec, mode, opts.Flags); err != nil {
+		if err := configureDeploymentForMode(dpl, mode, opts.Flags); err != nil {
 			return nil, err
 		}
 
@@ -344,7 +344,7 @@ func gatewayConfigOptions(opt Options) gateway.Options {
 func configureGatewayMetricsPKI(podSpec *corev1.PodSpec, serviceName string) error {
 	var gwIndex int
 	for i, c := range podSpec.Containers {
-		if c.Name == LabelGatewayComponent {
+		if c.Name == gatewayContainerName {
 			gwIndex = i
 			break
 		}

--- a/internal/manifests/internal/config/build_test.go
+++ b/internal/manifests/internal/config/build_test.go
@@ -10,7 +10,7 @@ import (
 func TestBuild_ConfigAndRuntimeConfig_NoRuntimeConfigGenerated(t *testing.T) {
 	expCfg := `
 ---
-auth_enabled: false
+auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
     enable_fifocache: yes
@@ -207,7 +207,7 @@ overrides:
 func TestBuild_ConfigAndRuntimeConfig_BothGenerated(t *testing.T) {
 	expCfg := `
 ---
-auth_enabled: false
+auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
     enable_fifocache: yes

--- a/internal/manifests/internal/config/loki-config.yaml
+++ b/internal/manifests/internal/config/loki-config.yaml
@@ -1,5 +1,5 @@
 ---
-auth_enabled: false
+auth_enabled: true
 chunk_store_config:
   chunk_cache_config:
     enable_fifocache: yes

--- a/internal/manifests/openshift/build.go
+++ b/internal/manifests/openshift/build.go
@@ -5,10 +5,16 @@ import "sigs.k8s.io/controller-runtime/pkg/client"
 // Build returns a list of auxiliary openshift/k8s objects
 // for lokistack gateway deployments on OpenShift.
 func Build(opts Options) []client.Object {
-	return []client.Object{
+	objs := []client.Object{
 		BuildRoute(opts),
 		BuildServiceAccount(opts),
 		BuildClusterRole(opts),
 		BuildClusterRoleBinding(opts),
 	}
+
+	if opts.BuildOpts.EnableCertificateSigningService {
+		objs = append(objs, BuildServiceCAConfigMap(opts))
+	}
+
+	return objs
 }

--- a/internal/manifests/openshift/build_test.go
+++ b/internal/manifests/openshift/build_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBuild_ServiceAccountRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{})
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
 
 	objs := Build(opts)
 	sa := objs[1].(*corev1.ServiceAccount)
@@ -24,7 +24,7 @@ func TestBuild_ServiceAccountRefMatches(t *testing.T) {
 }
 
 func TestBuild_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{})
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
 
 	objs := Build(opts)
 	cr := objs[2].(*rbacv1.ClusterRole)
@@ -35,7 +35,7 @@ func TestBuild_ClusterRoleRefMatches(t *testing.T) {
 }
 
 func TestBuild_ServiceAccountAnnotationsRouteRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{})
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
 
 	objs := Build(opts)
 	rt := objs[0].(*routev1.Route)

--- a/internal/manifests/openshift/options.go
+++ b/internal/manifests/openshift/options.go
@@ -36,16 +36,22 @@ type AuthorizationSpec struct {
 // extra lokistack gateway k8s objects (e.g. ServiceAccount, Route, RBAC)
 // on openshift.
 type BuildOptions struct {
-	LokiStackName        string
-	GatewayName          string
-	GatewayNamespace     string
-	GatewaySvcName       string
-	GatewaySvcTargetPort string
-	Labels               map[string]string
+	LokiStackName                   string
+	GatewayName                     string
+	GatewayNamespace                string
+	GatewaySvcName                  string
+	GatewaySvcTargetPort            string
+	Labels                          map[string]string
+	EnableCertificateSigningService bool
 }
 
 // NewOptions returns an openshift options struct.
-func NewOptions(stackName, gwName, gwNamespace, gwBaseDomain, gwSvcName, gwPortName string, gwLabels map[string]string) Options {
+func NewOptions(
+	stackName string,
+	gwName, gwNamespace, gwBaseDomain, gwSvcName, gwPortName string,
+	gwLabels map[string]string,
+	enableCertSigningService bool,
+) Options {
 	host := ingressHost(stackName, gwNamespace, gwBaseDomain)
 
 	var authn []AuthenticationSpec
@@ -61,12 +67,13 @@ func NewOptions(stackName, gwName, gwNamespace, gwBaseDomain, gwSvcName, gwPortN
 
 	return Options{
 		BuildOpts: BuildOptions{
-			LokiStackName:        stackName,
-			GatewayName:          gwName,
-			GatewayNamespace:     gwNamespace,
-			GatewaySvcName:       gwSvcName,
-			GatewaySvcTargetPort: gwPortName,
-			Labels:               gwLabels,
+			LokiStackName:                   stackName,
+			GatewayName:                     gwName,
+			GatewayNamespace:                gwNamespace,
+			GatewaySvcName:                  gwSvcName,
+			GatewaySvcTargetPort:            gwPortName,
+			Labels:                          gwLabels,
+			EnableCertificateSigningService: enableCertSigningService,
 		},
 		Authentication: authn,
 		Authorization: AuthorizationSpec{

--- a/internal/manifests/openshift/service_ca.go
+++ b/internal/manifests/openshift/service_ca.go
@@ -1,0 +1,26 @@
+package openshift
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BuildServiceCAConfigMap returns a k8s configmap for the LokiStack
+// gateway serviceCA configmap. This configmap is used to configure
+// the gateway to proxy server-side TLS encrypted requests to Loki.
+func BuildServiceCAConfigMap(opts Options) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				InjectCABundleKey: "true",
+			},
+			Labels:    opts.BuildOpts.Labels,
+			Name:      serviceCABundleName(opts),
+			Namespace: opts.BuildOpts.GatewayNamespace,
+		},
+	}
+}

--- a/internal/manifests/openshift/serviceaccount_test.go
+++ b/internal/manifests/openshift/serviceaccount_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildServiceAccount_AnnotationsMatchDefaultTenants(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{})
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
 
 	sa := BuildServiceAccount(opts)
 	require.Len(t, sa.GetAnnotations(), len(defaultTenants))

--- a/internal/manifests/openshift/var.go
+++ b/internal/manifests/openshift/var.go
@@ -20,9 +20,17 @@ var (
 	cookieSecretLength = 32
 	allowedRunes       = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
-	// ServingCertKey is the annotation key for using the cert-signing service
-	// on k8s service objects.
+	defaultConfigMapMode = int32(420)
+
+	// ServingCertKey is the annotation key for services used the
+	// cert-signing service to create a new key/cert pair signed
+	// by the service CA stored in a secret with the same name
+	// as the annotated service.
 	ServingCertKey = "service.beta.openshift.io/serving-cert-secret-name"
+	// InjectCABundleKey is the annotation key for configmaps used by the
+	// cert-signing service to inject the service CA into the annotated
+	// configmap.
+	InjectCABundleKey = "service.beta.openshift.io/inject-cabundle"
 )
 
 func clusterRoleName(opts Options) string {
@@ -39,6 +47,10 @@ func routeName(opts Options) string {
 
 func serviceAccountName(opts Options) string {
 	return opts.BuildOpts.GatewayName
+}
+
+func serviceCABundleName(opts Options) string {
+	return fmt.Sprintf("%s-ca-bundle", opts.BuildOpts.GatewayName)
 }
 
 func serviceAccountAnnotations(opts Options) map[string]string {


### PR DESCRIPTION
This PR introduces mounting the [service CA](https://docs.openshift.com/container-platform/4.8/security/certificate_types_descriptions/service-ca-certificates.html) in lokistack-gateway when the `EnableTLSServiceMonitorConfig` and `EnableCertificateSigningService` are used for Loki. I.e. enabling both flags configures for all Loki components to serve only via HTTPS. Thus the lokistack-gateway requires the CA to verify the Loki endpoint server side certificates. The CA file is mounted in form of a configmap which gets the CA certificated injected by the OpenShift cert-signing service.