### PR TITLE
LOG-1874: lokistack-gateway component restarting too many times on OpenShift

### DIFF
--- a/internal/handlers/internal/gateway/base_domain.go
+++ b/internal/handlers/internal/gateway/base_domain.go
@@ -23,10 +23,15 @@ func GetOpenShiftBaseDomain(ctx context.Context, k k8s.Client, req ctrl.Request)
 	if err := k.Get(ctx, key, &cluster); err != nil {
 
 		if apierrors.IsNotFound(err) {
-			return "", status.SetDegradedCondition(ctx, k, req,
+			statusErr := status.SetDegradedCondition(ctx, k, req,
 				"Missing cluster DNS configuration to read base domain",
 				lokiv1beta1.ReasonMissingGatewayOpenShiftBaseDomain,
 			)
+			if statusErr != nil {
+				return "", statusErr
+			}
+
+			return "", kverrors.Wrap(err, "Missing cluster DNS configuration to read base domain")
 		}
 		return "", kverrors.Wrap(err, "failed to lookup lokistack gateway base domain",
 			"name", key)

--- a/internal/handlers/internal/gateway/tenant_configmap.go
+++ b/internal/handlers/internal/gateway/tenant_configmap.go
@@ -1,0 +1,90 @@
+package gateway
+
+import (
+	"context"
+
+	"github.com/ViaQ/loki-operator/internal/manifests/openshift"
+
+	"github.com/ViaQ/logerr/log"
+
+	"github.com/ViaQ/logerr/kverrors"
+	"github.com/ViaQ/loki-operator/internal/manifests"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	"sigs.k8s.io/yaml"
+
+	"github.com/ViaQ/loki-operator/internal/external/k8s"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// LokiGatewayTenantFileName is the name of the tenant config file in the configmap
+	LokiGatewayTenantFileName = "tenants.yaml"
+)
+
+type tenantsConfigJSON struct {
+	Tenants []tenantsSpec `json:"tenants,omitempty"`
+}
+
+type tenantsSpec struct {
+	Name      string         `json:"name"`
+	ID        string         `json:"id"`
+	OpenShift *openShiftSpec `json:"openshift"`
+}
+
+type openShiftSpec struct {
+	ServiceAccount string `json:"serviceAccount"`
+	RedirectURL    string `json:"redirectURL"`
+	CookieSecret   string `json:"cookieSecret"`
+}
+
+// GetTenantConfigMapData returns the tenantName, tenantId, cookieSecret
+// clusters to auto-create redirect URLs for OpenShift Auth or an error.
+func GetTenantConfigMapData(ctx context.Context, k k8s.Client, req ctrl.Request) map[string]openshift.TenantData {
+	var tenantConfigMap corev1.ConfigMap
+	key := client.ObjectKey{Name: manifests.LabelGatewayComponent, Namespace: req.Namespace}
+	if err := k.Get(ctx, key, &tenantConfigMap); err != nil {
+		log.Error(err, "couldn't find")
+		return nil
+	}
+
+	tcm, err := extractTenantConfigMap(&tenantConfigMap)
+	if err != nil {
+		log.Error(err, "error occurred in extracting tenants.yaml configMap.")
+		return nil
+	}
+
+	tcmMap := make(map[string]openshift.TenantData)
+	for _, tenant := range tcm.Tenants {
+		tcmMap[tenant.Name] = openshift.TenantData{
+			TenantID:     tenant.ID,
+			CookieSecret: tenant.OpenShift.CookieSecret,
+		}
+	}
+
+	return tcmMap
+}
+
+// extractTenantConfigMap extracts tenants.yaml data if valid.
+// This is to be used to configure tenant's authentication spec when exists.
+func extractTenantConfigMap(cm *corev1.ConfigMap) (*tenantsConfigJSON, error) {
+	// Extract required fields from tenants.yaml
+	tenantConfigYAML, ok := cm.BinaryData[LokiGatewayTenantFileName]
+	if !ok {
+		return nil, kverrors.New("missing tenants.yaml file in configMap.")
+	}
+
+	tenantConfigJSON, err := yaml.YAMLToJSON(tenantConfigYAML)
+	if err != nil {
+		return nil, kverrors.New("error in converting tenant config yaml to json.")
+	}
+
+	var tenantConfig tenantsConfigJSON
+	err = json.Unmarshal(tenantConfigJSON, &tenantConfig)
+	if err != nil {
+		return nil, kverrors.New("error in unmarshalling tenant config to struct.")
+	}
+
+	return &tenantConfig, nil
+}

--- a/internal/handlers/internal/gateway/tenant_configmap_test.go
+++ b/internal/handlers/internal/gateway/tenant_configmap_test.go
@@ -1,0 +1,96 @@
+package gateway
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ViaQ/loki-operator/internal/manifests/openshift"
+
+	"github.com/ViaQ/loki-operator/internal/external/k8s/k8sfakes"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var tenantConfigData = []byte(`
+tenants:
+- name: application
+  id: test-123
+  openshift:
+    serviceAccount: lokistack-gateway-lokistack-dev
+    cookieSecret: test123
+- name: infrastructure
+  id: test-456
+  openshift:
+    serviceAccount: lokistack-gateway-lokistack-dev
+    cookieSecret: test456
+- name: audit
+  id: test-789
+  openshift:
+    serviceAccount: lokistack-gateway-lokistack-dev
+    cookieSecret: test789
+`)
+
+func TestGetTenantConfigMapData_ConfigMapExist(t *testing.T) {
+	k := &k8sfakes.FakeClient{}
+	r := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "lokistack-gateway",
+			Namespace: "some-ns",
+		},
+	}
+
+	k.GetStub = func(_ context.Context, name types.NamespacedName, object client.Object) error {
+		if name.Name == "lokistack-gateway" && name.Namespace == "some-ns" {
+			k.SetClientObject(object, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "lokistack-gateway",
+					Namespace: "some-ns",
+				},
+				BinaryData: map[string][]byte{
+					"tenants.yaml": tenantConfigData,
+				},
+			})
+		}
+		return nil
+	}
+
+	ts := GetTenantConfigMapData(context.TODO(), k, r)
+	require.NotNil(t, ts)
+
+	expected := map[string]openshift.TenantData{
+		"application": {
+			TenantID:     "test-123",
+			CookieSecret: "test123",
+		},
+		"infrastructure": {
+			TenantID:     "test-456",
+			CookieSecret: "test456",
+		},
+		"audit": {
+			TenantID:     "test-789",
+			CookieSecret: "test789",
+		},
+	}
+	require.Equal(t, expected, ts)
+}
+
+func TestGetTenantConfigMapData_ConfigMapNotExist(t *testing.T) {
+	k := &k8sfakes.FakeClient{}
+	r := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "lokistack-gateway",
+			Namespace: "some-ns",
+		},
+	}
+
+	k.GetStub = func(_ context.Context, name types.NamespacedName, object client.Object) error {
+		return nil
+	}
+
+	ts := GetTenantConfigMapData(context.TODO(), k, r)
+	require.Nil(t, ts)
+}

--- a/internal/handlers/lokistack_create_or_update_test.go
+++ b/internal/handlers/lokistack_create_or_update_test.go
@@ -859,7 +859,7 @@ func TestCreateOrUpdateLokiStack_WhenMissingGatewaySecret_SetDegraded(t *testing
 	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, ff)
 
 	// make sure error is returned to re-trigger reconciliation
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	// make sure status and status-update calls
 	require.NotZero(t, k.StatusCallCount())
@@ -942,7 +942,7 @@ func TestCreateOrUpdateLokiStack_WhenInvalidGatewaySecret_SetDegraded(t *testing
 	err := handlers.CreateOrUpdateLokiStack(context.TODO(), r, k, scheme, ff)
 
 	// make sure error is returned to re-trigger reconciliation
-	require.NoError(t, err)
+	require.Error(t, err)
 
 	// make sure status and status-update calls
 	require.NotZero(t, k.StatusCallCount())

--- a/internal/manifests/gateway.go
+++ b/internal/manifests/gateway.go
@@ -49,7 +49,7 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 
 	if opts.Stack.Tenants != nil {
 		mode := opts.Stack.Tenants.Mode
-		if err := configureDeploymentForMode(dpl, mode, opts.Flags, opts.Name); err != nil {
+		if err := configureDeploymentForMode(dpl, mode, opts.Flags); err != nil {
 			return nil, err
 		}
 

--- a/internal/manifests/gateway.go
+++ b/internal/manifests/gateway.go
@@ -49,7 +49,7 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 
 	if opts.Stack.Tenants != nil {
 		mode := opts.Stack.Tenants.Mode
-		if err := configureDeploymentForMode(dpl, mode, opts.Flags); err != nil {
+		if err := configureDeploymentForMode(dpl, mode, opts.Flags, opts.Name); err != nil {
 			return nil, err
 		}
 

--- a/internal/manifests/gateway.go
+++ b/internal/manifests/gateway.go
@@ -331,12 +331,21 @@ func gatewayConfigOptions(opt Options) gateway.Options {
 		gatewaySecrets = append(gatewaySecrets, gatewaySecret)
 	}
 
+	tenantConfigMap := make(map[string]gateway.TenantData)
+	for tenant, tenantData := range opt.TenantConfigMap {
+		tenantConfigMap[tenant] = gateway.TenantData{
+			TenantID:     tenantData.TenantID,
+			CookieSecret: tenantData.CookieSecret,
+		}
+	}
+
 	return gateway.Options{
 		Stack:            opt.Stack,
 		Namespace:        opt.Namespace,
 		Name:             opt.Name,
 		OpenShiftOptions: opt.OpenShiftOptions,
 		TenantSecrets:    gatewaySecrets,
+		TenantConfigMap:  tenantConfigMap,
 	}
 }
 

--- a/internal/manifests/gateway_tenants.go
+++ b/internal/manifests/gateway_tenants.go
@@ -47,7 +47,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 	return nil
 }
 
-func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags, stackName string) error {
+func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags) error {
 	switch mode {
 	case lokiv1beta1.Static, lokiv1beta1.Dynamic:
 		return nil // nothing to configure
@@ -55,7 +55,6 @@ func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType,
 		return openshift.ConfigureGatewayDeployment(
 			d,
 			gatewayContainerName,
-			GatewayName(stackName),
 			tlsMetricsSercetVolume,
 			gateway.LokiGatewayTLSDir,
 			gateway.LokiGatewayCertFile,

--- a/internal/manifests/gateway_tenants.go
+++ b/internal/manifests/gateway_tenants.go
@@ -36,6 +36,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 			gatewayHTTPPortName,
 			ComponentLabels(LabelGatewayComponent, opts.Name),
 			opts.Flags.EnableCertificateSigningService,
+			opts.TenantConfigMap,
 		)
 
 		if err := mergo.Merge(&opts.OpenShiftOptions, &defaults, mergo.WithOverride); err != nil {

--- a/internal/manifests/gateway_tenants.go
+++ b/internal/manifests/gateway_tenants.go
@@ -47,7 +47,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 	return nil
 }
 
-func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags) error {
+func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType, flags FeatureFlags, stackName string) error {
 	switch mode {
 	case lokiv1beta1.Static, lokiv1beta1.Dynamic:
 		return nil // nothing to configure
@@ -55,6 +55,7 @@ func configureDeploymentForMode(d *appsv1.Deployment, mode lokiv1beta1.ModeType,
 		return openshift.ConfigureGatewayDeployment(
 			d,
 			gatewayContainerName,
+			GatewayName(stackName),
 			tlsMetricsSercetVolume,
 			gateway.LokiGatewayTLSDir,
 			gateway.LokiGatewayCertFile,

--- a/internal/manifests/internal/gateway/options.go
+++ b/internal/manifests/internal/gateway/options.go
@@ -15,6 +15,7 @@ type Options struct {
 
 	OpenShiftOptions openshift.Options
 	TenantSecrets    []*Secret
+	TenantConfigMap  map[string]TenantData
 }
 
 // Secret for clientID, clientSecret and issuerCAPath for tenant's authentication.
@@ -23,4 +24,10 @@ type Secret struct {
 	ClientID     string
 	ClientSecret string
 	IssuerCAPath string
+}
+
+// TenantData defines the existing tenantID and cookieSecret for lokistack reconcile.
+type TenantData struct {
+	TenantID     string
+	CookieSecret string
 }

--- a/internal/manifests/openshift/build_test.go
+++ b/internal/manifests/openshift/build_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBuild_ServiceAccountRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
 
 	objs := Build(opts)
 	sa := objs[1].(*corev1.ServiceAccount)
@@ -24,7 +24,7 @@ func TestBuild_ServiceAccountRefMatches(t *testing.T) {
 }
 
 func TestBuild_ClusterRoleRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
 
 	objs := Build(opts)
 	cr := objs[2].(*rbacv1.ClusterRole)
@@ -35,7 +35,7 @@ func TestBuild_ClusterRoleRefMatches(t *testing.T) {
 }
 
 func TestBuild_ServiceAccountAnnotationsRouteRefMatches(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
 
 	objs := Build(opts)
 	rt := objs[0].(*routev1.Route)

--- a/internal/manifests/openshift/options.go
+++ b/internal/manifests/openshift/options.go
@@ -1,9 +1,10 @@
 package openshift
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"math/rand"
+
+	"github.com/google/uuid"
 )
 
 // Options is the set of internal template options for rendering
@@ -44,27 +45,41 @@ type BuildOptions struct {
 	EnableCertificateSigningService bool
 }
 
+// TenantData defines the existing tenantID and cookieSecret for lokistack reconcile.
+type TenantData struct {
+	TenantID     string
+	CookieSecret string
+}
+
 // NewOptions returns an openshift options struct.
 func NewOptions(
 	stackName string,
 	gwName, gwNamespace, gwBaseDomain, gwSvcName, gwPortName string,
 	gwLabels map[string]string,
 	enableCertSigningService bool,
+	tenantConfigMap map[string]TenantData,
 ) Options {
 	host := ingressHost(stackName, gwNamespace, gwBaseDomain)
 
 	var authn []AuthenticationSpec
 	for _, name := range defaultTenants {
-		s := sha1.New()
-		s.Write([]byte(name))
-		tenantID := s.Sum(nil)
-		authn = append(authn, AuthenticationSpec{
-			TenantName:     name,
-			TenantID:       fmt.Sprintf("%x", tenantID),
-			ServiceAccount: gwName,
-			RedirectURL:    fmt.Sprintf("http://%s/openshift/%s/callback", host, name),
-			CookieSecret:   newCookieSecret(),
-		})
+		if tenantConfigMap != nil {
+			authn = append(authn, AuthenticationSpec{
+				TenantName:     name,
+				TenantID:       tenantConfigMap[name].TenantID,
+				ServiceAccount: gwName,
+				RedirectURL:    fmt.Sprintf("http://%s/openshift/%s/callback", host, name),
+				CookieSecret:   tenantConfigMap[name].CookieSecret,
+			})
+		} else {
+			authn = append(authn, AuthenticationSpec{
+				TenantName:     name,
+				TenantID:       uuid.New().String(),
+				ServiceAccount: gwName,
+				RedirectURL:    fmt.Sprintf("http://%s/openshift/%s/callback", host, name),
+				CookieSecret:   newCookieSecret(),
+			})
+		}
 	}
 
 	return Options{

--- a/internal/manifests/openshift/options.go
+++ b/internal/manifests/openshift/options.go
@@ -1,10 +1,9 @@
 package openshift
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"math/rand"
-
-	"github.com/google/uuid"
 )
 
 // Options is the set of internal template options for rendering
@@ -56,9 +55,12 @@ func NewOptions(
 
 	var authn []AuthenticationSpec
 	for _, name := range defaultTenants {
+		s := sha1.New()
+		s.Write([]byte(name))
+		tenantID := s.Sum(nil)
 		authn = append(authn, AuthenticationSpec{
 			TenantName:     name,
-			TenantID:       uuid.New().String(),
+			TenantID:       fmt.Sprintf("%x", tenantID),
 			ServiceAccount: gwName,
 			RedirectURL:    fmt.Sprintf("http://%s/openshift/%s/callback", host, name),
 			CookieSecret:   newCookieSecret(),

--- a/internal/manifests/openshift/serviceaccount_test.go
+++ b/internal/manifests/openshift/serviceaccount_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestBuildServiceAccount_AnnotationsMatchDefaultTenants(t *testing.T) {
-	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false)
+	opts := NewOptions("abc", "abc", "efgh", "example.com", "abc", "abc", map[string]string{}, false, map[string]TenantData{})
 
 	sa := BuildServiceAccount(opts)
 	require.Len(t, sa.GetAnnotations(), len(defaultTenants))

--- a/internal/manifests/options.go
+++ b/internal/manifests/options.go
@@ -25,6 +25,7 @@ type Options struct {
 
 	OpenShiftOptions openshift.Options
 	TenantSecrets    []*TenantSecrets
+	TenantConfigMap  map[string]openshift.TenantData
 }
 
 // ObjectStorage for storage config.


### PR DESCRIPTION
This PR:
- fixes serviceAccount issue of gateway for static, dynamic modes. Currently, we were setting ServiceAccountName for all the 3 modes but this is not correct as we don't create any ServiceAccount for static and dynamic modes. Hence the deployment errors out saying missing ServiceAccountName and a reconcile error occurs. Hence moved this to openshift specific deployment configuration (this was done in #101)
- degraded condition on the lokistack was getting set but the deployments were still taking places because of the non-nil error returned by `SetDegradedCondition` function.
- fixed the `uuid` and `cookieSecret` issue by fetching the existing tenants.yaml configuration and using the same value in subsequent reconcile. Both uuid and cookieSecret will be created only once.

/cc @periklis 

### Links
- Jira: https://issues.redhat.com/browse/LOG-1874