### PR TITLE
Fix local kind deployments

### DIFF
--- a/bundle/manifests/loki-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/loki-operator.clusterserviceversion.yaml
@@ -581,6 +581,7 @@ spec:
               containers:
               - args:
                 - --with-lokistack-gateway
+                - --with-lokistack-gateway-route
                 - --with-cert-signing-service
                 - --with-service-monitors
                 - --with-tls-service-monitors

--- a/config/overlays/development/kustomization.yaml
+++ b/config/overlays/development/kustomization.yaml
@@ -19,4 +19,4 @@ commonLabels:
 
 patchesStrategicMerge:
 - manager_related_image_patch.yaml
-- manager_run_flags_patch.yaml
+- manager_image_pull_policy_patch.yaml

--- a/config/overlays/development/manager_image_pull_policy_patch.yaml
+++ b/config/overlays/development/manager_image_pull_policy_patch.yaml
@@ -7,5 +7,4 @@ spec:
     spec:
       containers:
         - name: manager
-          args:
-          - "--with-lokistack-gateway"
+          imagePullPolicy: Always

--- a/config/overlays/openshift/manager_run_flags_patch.yaml
+++ b/config/overlays/openshift/manager_run_flags_patch.yaml
@@ -9,6 +9,7 @@ spec:
         - name: manager
           args:
           - "--with-lokistack-gateway"
+          - "--with-lokistack-gateway-route"
           - "--with-cert-signing-service"
           - "--with-service-monitors"
           - "--with-tls-service-monitors"

--- a/controllers/lokistack_controller.go
+++ b/controllers/lokistack_controller.go
@@ -145,7 +145,7 @@ func (r *LokiStackReconciler) SetupWithManager(mgr manager.Manager) error {
 }
 
 func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
-	return bld.
+	bld = bld.
 		For(&lokiv1beta1.LokiStack{}, createOrUpdateOnlyPred).
 		Owns(&corev1.ConfigMap{}, updateOrDeleteOnlyPred).
 		Owns(&corev1.ServiceAccount{}, updateOrDeleteOnlyPred).
@@ -153,8 +153,13 @@ func (r *LokiStackReconciler) buildController(bld k8s.Builder) error {
 		Owns(&appsv1.Deployment{}, updateOrDeleteOnlyPred).
 		Owns(&appsv1.StatefulSet{}, updateOrDeleteOnlyPred).
 		Owns(&rbacv1.ClusterRole{}, updateOrDeleteOnlyPred).
-		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred).
-		Owns(&networkingv1.Ingress{}, updateOrDeleteOnlyPred).
-		Owns(&routev1.Route{}, updateOrDeleteOnlyPred).
-		Complete(r)
+		Owns(&rbacv1.ClusterRoleBinding{}, updateOrDeleteOnlyPred)
+
+	if r.Flags.EnableGatewayRoute {
+		bld = bld.Owns(&routev1.Route{}, updateOrDeleteOnlyPred)
+	} else {
+		bld = bld.Owns(&networkingv1.Ingress{}, updateOrDeleteOnlyPred)
+	}
+
+	return bld.Complete(r)
 }

--- a/hack/lokistack_dev.yaml
+++ b/hack/lokistack_dev.yaml
@@ -8,4 +8,4 @@ spec:
   storage:
     secret:
       name: test
-  storageClassName: gp2
+  storageClassName: standard

--- a/internal/manifests/gateway.go
+++ b/internal/manifests/gateway.go
@@ -66,7 +66,6 @@ func BuildGateway(opts Options) ([]client.Object, error) {
 // NewGatewayDeployment creates a deployment object for a lokiStack-gateway
 func NewGatewayDeployment(opts Options, sha1C string) *appsv1.Deployment {
 	podSpec := corev1.PodSpec{
-		ServiceAccountName: GatewayName(opts.Name),
 		Volumes: []corev1.Volume{
 			{
 				Name: "rbac",

--- a/internal/manifests/gateway_tenants.go
+++ b/internal/manifests/gateway_tenants.go
@@ -18,6 +18,10 @@ import (
 // tenant mode. Currently nothing is applied for modes static and dynamic. For mode openshift-logging
 // the tenant spec is filled with defaults for authentication and authorization.
 func ApplyGatewayDefaultOptions(opts *Options) error {
+	if opts.Stack.Tenants == nil {
+		return nil
+	}
+
 	switch opts.Stack.Tenants.Mode {
 	case lokiv1beta1.Static, lokiv1beta1.Dynamic:
 		return nil // continue using user input
@@ -37,6 +41,7 @@ func ApplyGatewayDefaultOptions(opts *Options) error {
 		if err := mergo.Merge(&opts.OpenShiftOptions, &defaults, mergo.WithOverride); err != nil {
 			return kverrors.Wrap(err, "failed to merge defaults for mode openshift logging")
 		}
+
 	}
 
 	return nil

--- a/internal/manifests/gateway_tenants_test.go
+++ b/internal/manifests/gateway_tenants_test.go
@@ -400,6 +400,7 @@ func TestConfigureDeploymentForMode(t *testing.T) {
 				Spec: appsv1.DeploymentSpec{
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
+							ServiceAccountName: "gateway",
 							Containers: []corev1.Container{
 								{
 									Name: gatewayContainerName,

--- a/internal/manifests/openshift/configure.go
+++ b/internal/manifests/openshift/configure.go
@@ -92,6 +92,7 @@ func ConfigureGatewayDeployment(
 	gwContainer.Args = gwArgs
 
 	p := corev1.PodSpec{
+		ServiceAccountName: d.GetName(),
 		Containers: []corev1.Container{
 			*gwContainer,
 			newOPAOpenShiftContainer(sercretVolumeName, tlsDir, certFile, keyFile, withTLS),

--- a/internal/manifests/options.go
+++ b/internal/manifests/options.go
@@ -42,6 +42,7 @@ type FeatureFlags struct {
 	EnableServiceMonitors           bool
 	EnableTLSServiceMonitorConfig   bool
 	EnableGateway                   bool
+	EnableGatewayRoute              bool
 }
 
 // TenantSecrets for clientID, clientSecret and issuerCAPath for tenant's authentication.


### PR DESCRIPTION
This PR provides a couple of fixes for working kind locally:
- Fix using OCP routes only if a `--with-lokistack-gateway-route` enabled. This is an OCP-only flag.
- Remove `--enable-lokistack-gateway` from `config/overlay/development` overlay for now as per kind missing a default ingress controller to make use of it.